### PR TITLE
Introduce replacement to Finder

### DIFF
--- a/src/Manager/AssetManager.php
+++ b/src/Manager/AssetManager.php
@@ -71,15 +71,6 @@ class AssetManager extends TrackingManager
 
         if (!$this->fs->exists($file)) { return; }
 
-        if (!($file instanceof SplFileInfo))
-        {
-            $file = new SplFileInfo(
-                $this->fs->absolutePath($file),
-                $this->fs->getFolderPath($file),
-                $file
-            );
-        }
-
         $filePath = $file->getRealPath();
         $pathToStrip = $this->fs->appendPath(getcwd(), $options['prefix']);
         $siteTargetPath = ltrim(str_replace($pathToStrip, "", $filePath), DIRECTORY_SEPARATOR);

--- a/src/Manager/BaseManager.php
+++ b/src/Manager/BaseManager.php
@@ -6,7 +6,6 @@ use allejo\stakx\Core\StakxLogger;
 use allejo\stakx\System\Filesystem;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseManager implements LoggerAwareInterface
 {

--- a/src/Manager/PageManager.php
+++ b/src/Manager/PageManager.php
@@ -102,12 +102,10 @@ class PageManager extends TrackingManager
                 continue;
             }
 
-            $finder = $this->fs->getFinder(array(), array(), $pageViewFolder);
-            $finder->name('/\.(html|twig)/');
-
-            $this->scanTrackableItems($finder, array(
+            // @TODO Replace this with a regular expression or have wildcard support
+            $this->scanTrackableItems($pageViewFolder, array(
                 'refresh' => false
-            ));
+            ), array('.html', '.twig'));
         }
     }
 

--- a/src/Manager/TrackingManager.php
+++ b/src/Manager/TrackingManager.php
@@ -8,6 +8,7 @@
 namespace allejo\stakx\Manager;
 
 use allejo\stakx\Object\FrontMatterObject;
+use allejo\stakx\System\FileExplorer;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -255,28 +256,17 @@ abstract class TrackingManager extends BaseManager
     /**
      * Parse the specified folder for items to track
      *
-     * @param Finder|string $pathOrFinder
+     * @param string $path
      * @param mixed  $options  Special options that will be passed to the static::parseTrackableItem() implementation
      * @param array  $includes
      * @param array  $excludes
      */
-    protected function scanTrackableItems ($pathOrFinder, $options = array(), $includes = array(), $excludes = array())
+    public function scanTrackableItems($path, $options = array(), $includes = array(), $excludes = array())
     {
-        if ($pathOrFinder instanceof Finder)
-        {
-            $finder = $pathOrFinder;
-        }
-        else
-        {
-            $finder = $this->fs->getFinder(
-                $includes,
-                $excludes,
-                $this->fs->absolutePath($pathOrFinder)
-            );
-        }
+        $fe = FileExplorer::create($path, $excludes, $includes);
+        $fileExplorer = $fe->getExplorer();
 
-        /** @var SplFileInfo $file */
-        foreach ($finder as $file)
+        foreach ($fileExplorer as $file)
         {
             $this->handleTrackableItem($file, $options);
         }

--- a/src/System/FileExplorer.php
+++ b/src/System/FileExplorer.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright 2016 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\System;
+
+class FileExplorer extends \RecursiveFilterIterator
+{
+    private $excludes;
+    private $includes;
+
+    /**
+     * FileExplorer constructor.
+     *
+     * @param \RecursiveIterator $iterator
+     * @param array              $excludes
+     */
+    public function __construct(\RecursiveIterator $iterator, array $excludes = array())
+    {
+        parent::__construct($iterator);
+
+        // I can't get this to work without hard coding it
+        $this->excludes = $excludes;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->current()->getFilename();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accept ()
+    {
+        return $this->strpos_array($this->current()->getPathname(), $this->excludes) === false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChildren()
+    {
+        return new self($this->getInnerIterator()->getChildren(), $this->excludes);
+    }
+
+    /**
+     * Get an Iterator with all of the files that have met the search requirements
+     *
+     * @return \RecursiveIteratorIterator
+     */
+    public function getExplorer ()
+    {
+        return (new \RecursiveIteratorIterator($this));
+    }
+
+    /**
+     * Create an instance of FileExplorer from a directory path as a string
+     *
+     * @param  string $folder   The path to the folder we're scanning
+     * @param  array  $excludes An array of
+     *
+     * @return FileExplorer
+     */
+    public static function create ($folder, $excludes = array())
+    {
+        $iterator = new \RecursiveDirectoryIterator($folder, \RecursiveDirectoryIterator::SKIP_DOTS);
+
+        return (new self($iterator, $excludes));
+    }
+
+    /**
+     * Search a given string for an array of possible elements
+     *
+     * @param  string   $haystack
+     * @param  string[] $needle
+     * @param  int      $offset
+     *
+     * @return bool True if an element from the given array was found in the string
+     */
+    private function strpos_array($haystack, $needle, $offset=0)
+    {
+        if (!is_array($needle))
+        {
+            $needle = array($needle);
+        }
+
+        foreach($needle as $query)
+        {
+            if (strpos($haystack, $query, $offset) !== false) // stop on first true result
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/System/FileExplorer.php
+++ b/src/System/FileExplorer.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\System;
 
+use Symfony\Component\Finder\SplFileInfo;
+
 class FileExplorer extends \RecursiveFilterIterator
 {
     /**
@@ -64,6 +66,23 @@ class FileExplorer extends \RecursiveFilterIterator
         if (preg_match('#(^|/)\..+(/|$)#', $filePath) === 1) { return false; }
 
         return ($this->strpos_array($filePath, $this->excludes) === false);
+    }
+
+    /**
+     * Get the current SplFileInfo object
+     *
+     * @return SplFileInfo
+     */
+    public function current()
+    {
+        /** @var \SplFileInfo $current */
+        $current = parent::current();
+
+        return (new SplFileInfo(
+            $current->getPathname(),
+            $this->getRelativePath($current->getPath()),
+            $this->getRelativePath($current->getPathname())
+        ));
     }
 
     /**
@@ -129,5 +148,17 @@ class FileExplorer extends \RecursiveFilterIterator
         }
 
         return false;
+    }
+
+    /**
+     * Strip the current working directory from an absolute path
+     *
+     * @param  string $path An absolute path
+     *
+     * @return string
+     */
+    private function getRelativePath ($path)
+    {
+        return str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $path);
     }
 }

--- a/src/System/FileSystem.php
+++ b/src/System/FileSystem.php
@@ -13,7 +13,6 @@ namespace allejo\stakx\System;
 
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
@@ -104,45 +103,6 @@ class Filesystem extends \Symfony\Component\Filesystem\Filesystem
     public function getRelativePath ($path)
     {
         return str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $path);
-    }
-
-    public function getFinder ($explicitIncludes = array(), $explicitIgnores = array(), $searchIn = "")
-    {
-        $finder = new Finder();
-        $finder->files()
-               ->ignoreVCS(true)
-               ->ignoreDotFiles(true)
-               ->ignoreUnreadableDirs();
-
-        $finder->in(
-            empty(trim($searchIn)) ? getcwd() : $searchIn
-        );
-
-        foreach ($explicitIgnores as $ignoreRule)
-        {
-            $isRegex = @preg_match($ignoreRule, null);
-
-            if (substr($ignoreRule, -1, 1) === '/' || $isRegex !== false)
-            {
-                $finder->notPath($ignoreRule);
-            }
-            else
-            {
-                $finder->notName($ignoreRule);
-            }
-        }
-
-        if (count($explicitIncludes) > 0)
-        {
-            foreach ($explicitIncludes as &$include)
-            {
-                $include = new SplFileInfo($include, $this->getFolderPath($include), $include);
-            }
-
-            $finder->append($explicitIncludes);
-        }
-
-        return $finder;
     }
 
     /**


### PR DESCRIPTION
### Description

<!--
  - Describe what bug or issue your pull request is fixing. If there is
    an existing issue, please reference that issue here as well.
  - Describe what new features your pull request are introducing.
-->

Using Symfony's Finder object caused some slowness during recursion through the filesystem while managing assets, so a new FileExplorer class has been introduced to take the place of it to improve speed. FileExplorer is a lightweight filesystem recursive iterator and each element will always be a `Symfony\Component\Finder\SplFileInfo` so this won't break compatibility with the rest of the manager classes.

This FileExplorer class will **not** take the place of the Twig Finder function provided as part of Stakx's core.

### Check List

- [x] All test passed
- [ ] Added test to ensure to fix/ensure properly.