### PR TITLE
Fix file paths on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Stakx
 
-[![Build Status](https://img.shields.io/travis/stakx-io/stakx.svg?maxAge=2592000)](https://travis-ci.org/stakx-io/stakx)
-[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/stakx-io/stakx.svg?maxAge=2592000)](https://scrutinizer-ci.com/g/stakx-io/stakx/?branch=master)
-[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/stakx-io/stakx.svg?maxAge=2592000)](https://scrutinizer-ci.com/g/stakx-io/stakx/?branch=master)
-[![Dependency Status](https://img.shields.io/versioneye/d/user/projects/57b8ba4e090d4d0039befe69.svg?maxAge=2592000)](https://www.versioneye.com/user/projects/57b8ba4e090d4d0039befe69)
+[![*nix build Status](https://img.shields.io/travis/stakx-io/stakx.svg)](https://travis-ci.org/stakx-io/stakx)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/0otqsetd0079jipd?svg=true)](https://ci.appveyor.com/project/allejo/stakx)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/stakx-io/stakx.svg?maxAge=7200)](https://scrutinizer-ci.com/g/stakx-io/stakx/?branch=master)
+[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/stakx-io/stakx.svg?maxAge=7200)](https://scrutinizer-ci.com/g/stakx-io/stakx/?branch=master)
+[![Dependency Status](https://img.shields.io/versioneye/d/user/projects/57b8ba4e090d4d0039befe69.svg?maxAge=7200)](https://www.versioneye.com/user/projects/57b8ba4e090d4d0039befe69)
 
 Stakx is a static website generator built in PHP as a powerful alternative to Jekyll or Sculpin. If you have PHP installed on your computer, download Stakx from our Releases and run it! There is no need to download dependencies (`bundle install` or `composer install`) like other tools, everything is bundled in a single executable that just works.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+build: false
+version: 0.1.0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+skip_tags: true
+clone_folder: C:\projects\stakx
+
+branches:
+  except:
+    - gh-pages
+
+install:
+  - cinst -y OpenSSL.Light
+  - SET PATH=C:\Program Files\OpenSSL;%PATH%
+  - cinst -y php --version 7.0.9
+  - cd c:\tools\php
+  - copy php.ini-production php.ini
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - SET PATH=C:\tools\php;%PATH%
+  - cd C:\projects\stakx
+  - php -r "readfile('http://getcomposer.org/installer');" | php
+  - php composer.phar install --prefer-source --no-interaction
+
+test_script:
+  - cd C:\projects\stakx
+  - vendor\bin\phpunit.bat
+
+notifications:
+  - provider: Webhook
+    url: http://helit.tech:8093/+sujevo-dev/showSuccessfulBuildMessages=always
+    on_build_success: true
+    on_build_failure: true
+    on_build_status_changed: true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,9 +5,14 @@
         colors="true">
     <testsuites>
         <testsuite name="Stakx Test Suite">
-            <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">tests</directory>
+            <directory suffix="Test.php" phpVersion="5.4.0" phpVersionOperator=">=">tests</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+    </php>
 
     <filter>
         <blacklist>

--- a/src/Object/FrontMatterObject.php
+++ b/src/Object/FrontMatterObject.php
@@ -240,15 +240,16 @@ abstract class FrontMatterObject
      */
     final public function getTargetFile ()
     {
-        $permalink  = $this->getPermalink();
-        $extension  = $this->fs->getExtension($permalink);
+        $permalink = $this->getPermalink();
+        $extension = $this->fs->getExtension($permalink);
+        $permalink = str_replace('/', DIRECTORY_SEPARATOR, $permalink);
 
         if (empty($extension))
         {
-            $permalink = rtrim($permalink, '/') . '/index.html';
+            $permalink = rtrim($permalink, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'index.html';
         }
 
-        return ltrim($permalink, '/');
+        return ltrim($permalink, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -470,7 +471,7 @@ abstract class FrontMatterObject
         $permalink = str_replace(' ', '-', $permalink);
 
         // Remove all disallowed characters
-        $permalink = preg_replace('/[^0-9a-zA-Z-_\/\.]/', '', $permalink);
+        $permalink = preg_replace('/[^0-9a-zA-Z-_\/\\\.]/', '', $permalink);
 
         // Handle unnecessary extensions
         $extensionsToStrip = array('twig');
@@ -481,7 +482,7 @@ abstract class FrontMatterObject
         }
 
         // Remove a special './' combination from the beginning of a path
-        if (substr($permalink, 0, 2) === './')
+        if (substr($permalink, 0, 2) === '.' . DIRECTORY_SEPARATOR)
         {
             $permalink = substr($permalink, 2);
         }

--- a/tests/FrontMatterObjectTests/ContentItemTest.php
+++ b/tests/FrontMatterObjectTests/ContentItemTest.php
@@ -6,6 +6,7 @@ use allejo\stakx\Engines\MarkdownEngine;
 use allejo\stakx\Engines\RstEngine;
 use allejo\stakx\Exception\YamlVariableUndefinedException;
 use allejo\stakx\Object\ContentItem;
+use allejo\stakx\System\Filesystem;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
@@ -32,11 +33,17 @@ class ContentItemTests extends PHPUnit_Framework_TestCase
      */
     protected $rootDir;
 
+    /**
+     * @var Filesystem
+     */
+    protected $fs;
+
     public function setUp ()
     {
         $this->fileTemplate = "---\n%s\n---\n\n%s";
         $this->dummyFile    = vfsStream::newFile('foo.html.twig');
         $this->rootDir      = vfsStream::setup();
+        $this->fs           = new Filesystem();
     }
 
     public function testContentItemFilePath ()
@@ -232,7 +239,7 @@ class ContentItemTests extends PHPUnit_Framework_TestCase
 
         $contentItem = $this->createSampleValidFile($frontMatter);
 
-        $this->assertEquals("about/index.html", $contentItem->getTargetFile());
+        $this->assertEquals($this->fs->appendPath('about', 'index.html'), $contentItem->getTargetFile());
     }
 
     public function testContentItemTargetFileFromPrettyUrlWithRedirects ()
@@ -247,7 +254,7 @@ class ContentItemTests extends PHPUnit_Framework_TestCase
         );
         $contentItem = $this->createSampleValidFile($frontMatter);
 
-        $this->assertEquals("canonical/index.html", $contentItem->getTargetFile());
+        $this->assertEquals($this->fs->appendPath('canonical', 'index.html'), $contentItem->getTargetFile());
         $this->assertEquals("/canonical/", $contentItem->getPermalink());
         $this->assertContains("/redirect/", $contentItem->getRedirects());
         $this->assertContains("/redirect-me/", $contentItem->getRedirects());
@@ -261,14 +268,14 @@ class ContentItemTests extends PHPUnit_Framework_TestCase
 
         $contentItem = $this->createSampleValidFile($frontMatter);
 
-        $this->assertEquals("home/about.html", $contentItem->getTargetFile());
+        $this->assertEquals($this->fs->appendPath('home', 'about.html'), $contentItem->getTargetFile());
     }
 
     public function testContentItemTargetFileFromFileWithoutPermalinkAtRoot ()
     {
         $contentItem = $this->createValidFileWithEmptyFrontMatter();
 
-        $this->assertEquals("root/foo.html", $contentItem->getTargetFile());
+        $this->assertEquals($this->fs->appendPath('root', 'foo.html'), $contentItem->getTargetFile());
     }
 
     public function testContentItemTargetFileFromFileWithoutPermalinkInDir ()
@@ -281,7 +288,7 @@ class ContentItemTests extends PHPUnit_Framework_TestCase
 
         $contentItem = new ContentItem($root->getChild('dir/foo.html.twig')->url());
 
-        $this->assertEquals('root/dir/foo.html', $contentItem->getTargetFile());
+        $this->assertEquals($this->fs->appendPath('root', 'dir', 'foo.html'), $contentItem->getTargetFile());
     }
 
     public function testContentItemTargetFileFromFileWithStakxDataFolder ()

--- a/tests/ManagerTests/CollectionManagerTest.php
+++ b/tests/ManagerTests/CollectionManagerTest.php
@@ -3,6 +3,7 @@
 namespace allejo\stakx\tests;
 
 use allejo\stakx\Manager\CollectionManager;
+use allejo\stakx\System\Filesystem;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,14 +15,21 @@ class CollectionManagerTests extends PHPUnit_Framework_TestCase
      */
     private $cm;
 
+    /**
+     * @var Filesystem
+     */
+    private $fs;
+
     public function setUp ()
     {
+        $this->fs = new Filesystem();
+
         $this->cm = new CollectionManager();
         $this->cm->setLogger($this->loggerMock());
         $this->cm->parseCollections(array(
             array(
                 'name' => 'Sample',
-                'folder' => __DIR__ . '/SampleCollection'
+                'folder' => __DIR__ . DIRECTORY_SEPARATOR . 'SampleCollection'
             )
         ));
     }
@@ -44,13 +52,19 @@ class CollectionManagerTests extends PHPUnit_Framework_TestCase
 
     public function testCollectionManagerContainsContentItem ()
     {
-        $this->assertTrue($this->cm->isTracked('tests/ManagerTests/SampleCollection/Tale-of-Despereaux.md'));
-        $this->assertTrue($this->cm->isTracked('tests/ManagerTests/SampleCollection/Tiger-Rising.md'));
+        $this->assertTrue($this->cm->isTracked(
+            $this->fs->appendPath('tests', 'ManagerTests', 'SampleCollection', 'Tale-of-Despereaux.md')
+        ));
+        $this->assertTrue($this->cm->isTracked(
+            $this->fs->appendPath('tests', 'ManagerTests', 'SampleCollection', 'Tiger-Rising.md')
+        ));
     }
 
     public function testCollectionManagerGetContentItem ()
     {
-        $contentItem = $this->cm->getContentItem('tests/ManagerTests/SampleCollection/Tiger-Rising.md');
+        $contentItem = $this->cm->getContentItem(
+            $this->fs->appendPath('tests', 'ManagerTests', 'SampleCollection', 'Tiger-Rising.md')
+        );
 
         $this->assertNotNull($contentItem);
         $this->assertEquals('Sample', $contentItem->getCollection());


### PR DESCRIPTION
### Description

Fix issues on Windows where file paths for target files have the wrong directory separator causing it to be sanitized out resulting in jumbledpathtofiles.html. In addition, I added an AppVeyor configuration file to run the unit tests on Windows to lessen the chances of me breaking something on Windows

### Check List

- [ ] ~Added appropriate PhpDoc for modifications~
- [x] Added unit test to ensure fix works as intended
