### PR TITLE
Fix permalinks based on file path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "build": [
       "composer install --no-dev",
       "box build",
-      "shasum stakx.phar > stakx.phar.version"
+      "php -r \"file_put_contents('stakx.phar.version', sha1_file('stakx.phar'));\""
     ]
   }
 }

--- a/src/Object/FrontMatterObject.php
+++ b/src/Object/FrontMatterObject.php
@@ -439,11 +439,11 @@ abstract class FrontMatterObject
     private function getPathPermalink ()
     {
         // Remove the protocol of the path, if there is one and prepend a '/' to the beginning
-        $cleanPath = preg_replace('/[\w|\d]+:\/\//', '', $this->filePath);
+        $cleanPath = preg_replace('/[\w|\d]+:\/\//', '', $this->getRelativeFilePath());
         $cleanPath = ltrim($cleanPath, DIRECTORY_SEPARATOR);
 
         // Check the first folder and see if it's a data folder (starts with an underscore) intended for stakx
-        $folders = explode('/', $cleanPath);
+        $folders = explode(DIRECTORY_SEPARATOR, $cleanPath);
 
         if (substr($folders[0], 0, 1) === '_')
         {

--- a/src/Object/FrontMatterObject.php
+++ b/src/Object/FrontMatterObject.php
@@ -442,6 +442,12 @@ abstract class FrontMatterObject
         $cleanPath = preg_replace('/[\w|\d]+:\/\//', '', $this->getRelativeFilePath());
         $cleanPath = ltrim($cleanPath, DIRECTORY_SEPARATOR);
 
+        // Handle vfs:// paths by replacing their forward slashes with the OS appropriate directory separator
+        if (DIRECTORY_SEPARATOR !== '/')
+        {
+            $cleanPath = str_replace('/', DIRECTORY_SEPARATOR, $cleanPath);
+        }
+
         // Check the first folder and see if it's a data folder (starts with an underscore) intended for stakx
         $folders = explode(DIRECTORY_SEPARATOR, $cleanPath);
 


### PR DESCRIPTION
### Description

Permalinks generated based on the file path when `permalink` wasn't set in the Front Matter would use the absolute path to the file

### Check List

- [ ] ~Added appropriate PhpDoc for modifications~
- [ ] ~Added unit test to ensure fix works as intended~
