### PR TITLE
Use current PHP on Windows testing again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,9 @@ cache:
 install:
   - cinst -y OpenSSL.Light
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
-  - cinst -y php --version 7.0.9
+  - sc config wuauserv start= auto
+  - net start wuauserv
+  - cinst -y php
   - cd c:\tools\php
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini


### PR DESCRIPTION
PHP 7.0.9 is broken(-ish) for AppVeyor testing again. Let's see if this fixes it