### PR TITLE
Make sure all objects given to Twig are jailed

### DIFF
--- a/src/Manager/CollectionManager.php
+++ b/src/Manager/CollectionManager.php
@@ -8,6 +8,7 @@
 namespace allejo\stakx\Manager;
 
 use allejo\stakx\Object\ContentItem;
+use allejo\stakx\Object\JailObject;
 
 /**
  * Class CollectionManager
@@ -41,6 +42,26 @@ class CollectionManager extends TrackingManager
     public function &getCollections ()
     {
         return $this->trackedItems;
+    }
+
+    /**
+     * Get jailed ContentItems
+     *
+     * @return JailObject[][]
+     */
+    public function getJailedCollections ()
+    {
+        $jailItems = array();
+
+        foreach ($this->trackedItems as $key => $items)
+        {
+            foreach ($items as $name => $contentItem)
+            {
+                $jailItems[$key][$name] = $contentItem->createJail();
+            }
+        }
+
+        return $jailItems;
     }
 
     /**

--- a/src/Manager/PageManager.php
+++ b/src/Manager/PageManager.php
@@ -121,7 +121,18 @@ class PageManager extends TrackingManager
      */
     public function getSiteMenu ()
     {
-        return $this->siteMenu;
+        static $jailedMenu = array();
+
+        if (!empty($jailedMenu)) {
+            return $jailedMenu;
+        }
+
+        foreach ($this->siteMenu as $key => $value)
+        {
+            $jailedMenu[$key] = $value->createJail();
+        }
+
+        return $jailedMenu;
     }
 
     /**
@@ -293,7 +304,7 @@ class PageManager extends TrackingManager
             $this->addToSiteMenu($pageView);
 
             if (!empty($pageView->title)) {
-                $this->flatPages[$pageView->title] = &$pageView;
+                $this->flatPages[$pageView->title] = $pageView->createJail();
             }
         }
     }

--- a/src/Object/JailObject.php
+++ b/src/Object/JailObject.php
@@ -15,7 +15,7 @@ namespace allejo\stakx\Object;
  *
  * @package allejo\stakx\Object
  */
-class JailObject
+class JailObject implements \ArrayAccess
 {
     /**
      * @var string[]
@@ -41,9 +41,9 @@ class JailObject
      */
     public function __construct (&$object, array $whiteListFunctions, array $jailedFunctions = array())
     {
-        if (!($object instanceof Jailable))
+        if (!($object instanceof Jailable) && !($object instanceof \ArrayAccess))
         {
-            throw new \InvalidArgumentException('Must implement Jailable interface');
+            throw new \InvalidArgumentException('Must implement the ArrayAccess and Jailable interfaces');
         }
 
         $this->object = &$object;
@@ -81,7 +81,7 @@ class JailObject
         throw new \BadMethodCallException();
     }
 
-    public function __get($name)
+    public function __get ($name)
     {
         if ($this->object->isMagicGet($name))
         {
@@ -89,5 +89,46 @@ class JailObject
         }
 
         return NULL;
+    }
+
+    public function coreInstanceOf ($class)
+    {
+        return is_subclass_of($this->object, $class);
+    }
+
+    //
+    // ArrayAccess Implementation
+    //
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return $this->object->offsetExists($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->object->offsetGet($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        return $this->object->offsetSet($offset, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        return $this->object->offsetUnset($offset);
     }
 }

--- a/src/Object/Website.php
+++ b/src/Object/Website.php
@@ -140,7 +140,7 @@ class Website
             'safe'    => $this->safeMode,
             'globals' => array(
                 array('name' => 'site',        'value' => $this->getConfiguration()->getConfiguration()),
-                array('name' => 'collections', 'value' => $this->cm->getCollections()),
+                array('name' => 'collections', 'value' => $this->cm->getJailedCollections()),
                 array('name' => 'menu',        'value' => $this->pm->getSiteMenu()),
                 array('name' => 'pages',       'value' => $this->pm->getFlatPages()),
                 array('name' => 'data',        'value' => $this->dm->getDataItems())

--- a/src/Twig/BaseUrlFunction.php
+++ b/src/Twig/BaseUrlFunction.php
@@ -2,7 +2,6 @@
 
 namespace allejo\stakx\Twig;
 
-use allejo\stakx\Object\FrontMatterObject;
 use Twig_Environment;
 
 class BaseUrlFunction
@@ -11,9 +10,11 @@ class BaseUrlFunction
     {
         $globals = $env->getGlobals();
 
-        if ($assetPath instanceof FrontMatterObject)
-        {
-            $assetPath = $assetPath->getPermalink();
+        if (is_array($assetPath) || ($assetPath instanceof \ArrayAccess)) {
+            $assetPath = $assetPath['permalink'];
+        }
+        else if (is_null($assetPath)) {
+            $assetPath = '/';
         }
 
         // @TODO 1.0.0 Remove support for 'base' as it's been deprecated

--- a/src/Twig/OrderFilter.php
+++ b/src/Twig/OrderFilter.php
@@ -2,8 +2,6 @@
 
 namespace allejo\stakx\Twig;
 
-use allejo\stakx\Object\FrontMatterObject;
-
 class OrderFilter
 {
     public function __invoke ($array, $key, $order = "ASC")
@@ -15,9 +13,6 @@ class OrderFilter
 
         usort($array, function ($a, $b) use ($key, $order)
         {
-            $a = ($a instanceof FrontMatterObject) ? $a->getFrontMatter() : $a;
-            $b = ($b instanceof FrontMatterObject) ? $b->getFrontMatter() : $b;
-
             if ($a[$key] == $b[$key])
             {
                 return 0;

--- a/src/Twig/WhereFilter.php
+++ b/src/Twig/WhereFilter.php
@@ -2,16 +2,15 @@
 
 namespace allejo\stakx\Twig;
 
-use allejo\stakx\Object\FrontMatterObject;
 use Twig_Error_Syntax;
 
 class WhereFilter
 {
     /**
-     * @param  array|FrontMatterObject[] $array      The elements to filter through
-     * @param  string                    $key        The key value in an associative array or FrontMatter
-     * @param  string                    $comparison The actual comparison symbols being used
-     * @param  mixed                     $value      The value we're searching for
+     * @param  array|\ArrayAccess[] $array      The elements to filter through
+     * @param  string               $key        The key value in an associative array or FrontMatter
+     * @param  string               $comparison The actual comparison symbols being used
+     * @param  mixed                $value      The value we're searching for
      *
      * @return array
      */
@@ -34,15 +33,15 @@ class WhereFilter
     /**
      * Recursive searching calling our comparison
      *
-     * @param array|FrontMatterObject[] $array      The elements to filter through
-     * @param string                    $key        The key value in an associative array or FrontMatter
-     * @param string                    $comparison The actual comparison symbols being used
-     * @param string                    $value      The value we're searching for
-     * @param array                     $results    The reference to where to keep the filtered elements
+     * @param array|\ArrayAccess[] $array      The elements to filter through
+     * @param string               $key        The key value in an associative array or FrontMatter
+     * @param string               $comparison The actual comparison symbols being used
+     * @param string               $value      The value we're searching for
+     * @param array                $results    The reference to where to keep the filtered elements
      */
     private function search_r ($array, $key, $comparison, $value, &$results)
     {
-        if (!is_array($array) && !($array instanceof FrontMatterObject))
+        if (!is_array($array) && !($array instanceof \ArrayAccess))
         {
             return;
         }
@@ -61,10 +60,10 @@ class WhereFilter
     /**
      * The logic for determining if an element matches the filter
      *
-     * @param  array|FrontMatterObject[] $array      The elements to filter through
-     * @param  string                    $key        The key value in an associative array or FrontMatter
-     * @param  string                    $comparison The actual comparison symbols being used
-     * @param  mixed                     $value      The value we're searching for
+     * @param  array|\ArrayAccess[] $array      The elements to filter through
+     * @param  string               $key        The key value in an associative array or FrontMatter
+     * @param  string               $comparison The actual comparison symbols being used
+     * @param  mixed                $value      The value we're searching for
      *
      * @return bool
      *
@@ -72,17 +71,9 @@ class WhereFilter
      */
     private function compare ($array, $key, $comparison, $value)
     {
-        $fm = false;
-
-        if ($array instanceof FrontMatterObject)
-        {
-            $array = $array->getFrontMatter();
-            $fm = true;
-        }
-
         if (!isset($array[$key]))
         {
-            return ($fm && $comparison === "==" && $value === null);
+            return false;
         }
 
         switch ($comparison)


### PR DESCRIPTION
### Description

Make sure all objects given to Twig are jailed. Have FrontMatterObjects implement ArrayAccess so Twig filters can have an easier time

### Check List

- [x] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
