### PR TITLE
Include the file path for invalid syntax exceptions.

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -4,7 +4,7 @@ namespace allejo\stakx\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use allejo\stakx\Exception\InvalidSyntaxException;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class BuildCommand extends BuildableCommand
 {
@@ -35,7 +35,7 @@ class BuildCommand extends BuildableCommand
                 $this->website->getConfiguration()->getTargetFolder() . DIRECTORY_SEPARATOR
             ));
         }
-        catch (InvalidSyntaxException $e)
+        catch (IOException $e)
         {
             $output->writeln(sprintf("Your website failed to build with the following error in file '%s': %s",
                 $e->getPath(),

--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -4,6 +4,7 @@ namespace allejo\stakx\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use allejo\stakx\Exception\InvalidSyntaxException;
 
 class BuildCommand extends BuildableCommand
 {
@@ -32,6 +33,13 @@ class BuildCommand extends BuildableCommand
 
             $output->writeln(sprintf("Your site built successfully! It can be found at: %s",
                 $this->website->getConfiguration()->getTargetFolder() . DIRECTORY_SEPARATOR
+            ));
+        }
+        catch (InvalidSyntaxException $e)
+        {
+            $output->writeln(sprintf("Your website failed to build with the following error in file '%s': %s",
+                $e->getPath(),
+                $e->getMessage()
             ));
         }
         catch (\Exception $e)


### PR DESCRIPTION
This change makes `BuildCommand::execute` catch `InvalidSyntaxException` so that the file path can also be displayed alongside the error message.