### PR TITLE
Ignore data files ending in .example

### DIFF
--- a/src/Manager/DataManager.php
+++ b/src/Manager/DataManager.php
@@ -53,7 +53,12 @@ class DataManager extends TrackingManager
         foreach ($folders as $folder)
         {
             $this->saveFolderDefinition($folder);
-            $this->scanTrackableItems($folder);
+            $this->scanTrackableItems(
+                $folder,
+                array(),
+                array(),
+                array('/\.example$/')
+            );
         }
     }
 
@@ -81,9 +86,12 @@ class DataManager extends TrackingManager
             $this->saveFolderDefinition($dataSet['folder'], array(
                 'namespace' => $dataSet['name']
             ));
-            $this->scanTrackableItems($dataSet['folder'], array(
-                'namespace' => $dataSet['name']
-            ));
+            $this->scanTrackableItems(
+                $dataSet['folder'],
+                array('namespace' => $dataSet['name']),
+                array(''),
+                array('/\.example$/')
+            );
         }
     }
 


### PR DESCRIPTION
This allows example data files to be included in the directory without build warnings being thrown.