### PR TITLE
Add 'import' keyword for _config.yml

### DIFF
--- a/.idea/stakx.iml
+++ b/.idea/stakx.iml
@@ -19,7 +19,7 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="PHP">
+      <library name="PHP" type="php">
         <CLASSES>
           <root url="file://$MODULE_DIR$/vendor/allejo/resource-watcher" />
           <root url="file://$MODULE_DIR$/vendor/aptoma/twig-markdown" />

--- a/src/allejo/stakx/Configuration.php
+++ b/src/allejo/stakx/Configuration.php
@@ -7,16 +7,22 @@
 
 namespace allejo\stakx;
 
+use allejo\stakx\Exception\FileAccessDeniedException;
+use allejo\stakx\Exception\RecursiveConfigurationException;
 use allejo\stakx\System\Filesystem;
 use allejo\stakx\Utilities\ArrayUtilities;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 class Configuration implements LoggerAwareInterface
 {
     const DEFAULT_NAME = '_config.yml';
+    const IMPORT_KEYWORD = 'import';
+
+    private static $configImports = array();
 
     /**
      * A list of regular expressions or files directly related to stakx websites that should not be copied over to the
@@ -32,6 +38,14 @@ class Configuration implements LoggerAwareInterface
      * @var array
      */
     private $configuration;
+
+    /**
+     * @var string
+     */
+    private $parentConfig;
+
+    /** @var string */
+    private $currentFile;
 
     /**
      * @var LoggerInterface
@@ -53,35 +67,6 @@ class Configuration implements LoggerAwareInterface
     }
 
     /**
-     * Parse a given configuration file and configure this Configuration instance.
-     *
-     * This function should be called with 'null' passed when "configuration-less" mode is used
-     *
-     * @param string|null $configFile The path to the configuration file. If null, the default configuration will be
-     *                                used
-     */
-    public function parseConfiguration($configFile = null)
-    {
-        if ($this->fs->exists($configFile))
-        {
-            try
-            {
-                $this->configuration = Yaml::parse(file_get_contents($configFile));
-            }
-            catch (ParseException $e)
-            {
-                $this->output->error('Parsing the configuration failed: {message}', array(
-                    'message' => $e->getMessage(),
-                ));
-                $this->output->error('Using default configuration...');
-            }
-        }
-
-        $this->defaultConfiguration();
-        $this->handleDeprecations();
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function setLogger(LoggerInterface $logger)
@@ -89,6 +74,13 @@ class Configuration implements LoggerAwareInterface
         $this->output = $logger;
     }
 
+    ///
+    // Getters
+    ///
+
+    /**
+     * @return bool
+     */
     public function isDebug()
     {
         return $this->returnConfigOption('debug', false);
@@ -128,46 +120,73 @@ class Configuration implements LoggerAwareInterface
         return $this->returnConfigOption('datasets');
     }
 
+    /**
+     * @return string[]
+     */
     public function getIncludes()
     {
         return $this->returnConfigOption('include', array());
     }
 
+    /**
+     * @return string[]
+     */
     public function getExcludes()
     {
         return $this->returnConfigOption('exclude', array());
     }
 
+    /**
+     * @return string
+     */
     public function getTheme()
     {
         return $this->returnConfigOption('theme');
     }
 
+    /**
+     * @return array
+     */
     public function getConfiguration()
     {
         return $this->configuration;
     }
 
+    /**
+     * @return string[]
+     */
     public function getPageViewFolders()
     {
         return $this->returnConfigOption('pageviews');
     }
 
+    /**
+     * @return string
+     */
     public function getTargetFolder()
     {
         return $this->returnConfigOption('target');
     }
 
+    /**
+     * @return string[][]
+     */
     public function getCollectionsFolders()
     {
         return $this->returnConfigOption('collections');
     }
 
+    /**
+     * @return bool
+     */
     public function getTwigAutoescape()
     {
         return $this->configuration['twig']['autoescape'];
     }
 
+    /**
+     * @return false|string
+     */
     public function getRedirectTemplate()
     {
         return $this->configuration['templates']['redirect'];
@@ -186,7 +205,99 @@ class Configuration implements LoggerAwareInterface
         return isset($this->configuration[$name]) ? $this->configuration[$name] : $default;
     }
 
-    private function defaultConfiguration()
+    ///
+    // Parsing
+    ///
+
+    /**
+     * Safely read a YAML configuration file and return an array representation of it.
+     *
+     * This function will only read files from within the website folder.
+     *
+     * @param  string $filePath
+     *
+     * @return array
+     */
+    private static function readFile($filePath)
+    {
+        $fs = new Filesystem();
+        $fileRaw = $fs->safeReadFile($filePath);
+        $parsed = Yaml::parse($fileRaw);
+
+        return (null === $parsed) ? array() : $parsed;
+    }
+
+    /**
+     * Parse a configuration file.
+     *
+     * @param string|null $configFile
+     */
+    public function parse($configFile = null)
+    {
+        $this->parentConfig = $this->fs->getRelativePath($configFile);
+        self::$configImports = array();
+
+        $this->configuration = $this->parseConfig($configFile);
+        $this->mergeDefaultConfiguration();
+        $this->handleDeprecations();
+
+        self::$configImports = array();
+    }
+
+    /**
+     * Parse a given configuration file and return an associative array representation.
+     *
+     * This function will automatically take care of imports in each file, whether it be a child or grandchild config
+     * file. `$configFile` should be called with 'null' when "configuration-less" mode is used.
+     *
+     * @param string|null $configFile     The path to the configuration file. If null, the default configuration will be
+     *                                    used
+     *
+     * @return array
+     */
+    private function parseConfig($configFile = null)
+    {
+        if (null === $configFile)
+        {
+            return array();
+        }
+
+        $this->currentFile = $configFile;
+
+        try
+        {
+            $this->isRecursiveImport($configFile);
+
+            $parsedConfig = self::readFile($configFile);
+
+            $this->handleImports($parsedConfig);
+
+            unset($parsedConfig[self::IMPORT_KEYWORD]);
+            return $parsedConfig;
+        }
+        catch (ParseException $e)
+        {
+            $this->output->error('{file}: parsing failed... {message}', array(
+                'message' => $e->getMessage(),
+                'file' => $configFile,
+            ));
+            $this->output->error('Using default configuration...');
+        }
+        catch (RecursiveConfigurationException $e)
+        {
+            $this->output->error("{file}: you can't recursively import a file that's already been imported: {import}", array(
+                'file' => $configFile,
+                'import' => $e->getRecursiveImport(),
+            ));
+        }
+
+        return array();
+    }
+
+    /**
+     * Merge the default configuration with the parsed configuration.
+     */
+    private function mergeDefaultConfiguration()
     {
         $defaultConfig = array(
             'baseurl'   => '',
@@ -210,6 +321,9 @@ class Configuration implements LoggerAwareInterface
         $this->configuration = ArrayUtilities::array_merge_defaults($defaultConfig, $this->configuration, 'name');
     }
 
+    /**
+     * Warn about deprecated keywords in the configuration file.
+     */
     private function handleDeprecations()
     {
         // @TODO 1.0.0 handle 'base' deprecation in _config.yml
@@ -219,5 +333,165 @@ class Configuration implements LoggerAwareInterface
         {
             $this->output->warning("The 'base' configuration option has been replaced by 'baseurl' and will be removed in in version 1.0.0.");
         }
+    }
+
+    /**
+     * Recursively resolve imports for a given array.
+     *
+     * This modifies the array in place.
+     *
+     * @param array $configuration
+     */
+    private function handleImports(array &$configuration)
+    {
+        if (!array_key_exists(self::IMPORT_KEYWORD, $configuration))
+        {
+            $this->output->debug('{file}: does not import any other files', array(
+                'file' => $this->parentConfig,
+            ));
+
+            return;
+        }
+
+        if (!is_array($imports = $configuration[self::IMPORT_KEYWORD]))
+        {
+            $this->output->error('{file}: the reserved "import" keyword can only be an array');
+
+            return;
+        }
+
+        $parentConfigLocation = $this->fs->getFolderPath($this->parentConfig);
+
+        foreach ($imports as $import)
+        {
+            $this->handleImport($import, $parentConfigLocation, $configuration);
+        }
+    }
+
+    /**
+     * Resolve a single import definition.
+     *
+     * @param string $importDef     The path for a given import; this will be treated as a relative path to the parent
+     *                              configuration
+     * @param string $parentConfLoc The path to the parent configuration
+     * @param array  $configuration The array representation of the current configuration; this will be modified in place
+     */
+    private function handleImport($importDef, $parentConfLoc, array &$configuration)
+    {
+        if (!is_string($importDef))
+        {
+            $this->output->error('{file}: invalid import: {message}', array(
+                'file' => $this->parentConfig,
+                'message' => $importDef,
+            ));
+
+            return;
+        }
+
+        $import = $this->fs->appendPath($parentConfLoc, $importDef);
+
+        if (!$this->isValidImport($import))
+        {
+            return;
+        }
+
+        $this->output->debug('{file}: imports additional file: {import}', array(
+            'file' => $this->parentConfig,
+            'import' => $import,
+        ));
+
+        try
+        {
+            $importedConfig = $this->parseConfig($import);
+            $configuration = $this->mergeImports($importedConfig, $configuration);
+        }
+        catch (FileAccessDeniedException $e)
+        {
+            $this->output->warning('{file}: trying access file outside of project directory: {import}', array(
+                'file' => $this->parentConfig,
+                'import' => $import,
+            ));
+        }
+        catch (FileNotFoundException $e)
+        {
+            $this->output->warning('{file}: could not find file to import: {import}', array(
+                'file' => $this->parentConfig,
+                'import' => $import,
+            ));
+        }
+    }
+
+    /**
+     * Check whether a given file path is a valid import.
+     *
+     * @param  string $filePath
+     *
+     * @return bool
+     */
+    private function isValidImport($filePath)
+    {
+        $errorMsg = '';
+
+        if ($this->fs->isDir($filePath))
+        {
+            $errorMsg = 'a directory';
+        }
+        elseif ($this->fs->isSymlink($filePath))
+        {
+            $errorMsg = 'a symbolically linked file';
+        }
+        elseif ($this->fs->absolutePath($this->currentFile) == $this->fs->absolutePath($filePath))
+        {
+            $errorMsg = 'yourself';
+        }
+        elseif (($ext = $this->fs->getExtension($filePath)) != 'yml' && $ext != 'yaml')
+        {
+            $errorMsg = 'a non-YAML configuration';
+        }
+
+        if (!($noErrors = empty($errorMsg)))
+        {
+            $this->output->error("{file}: you can't import {message}: {import}", array(
+                'file' => $this->parentConfig,
+                'message' => $errorMsg,
+                'import' => $filePath
+            ));
+        }
+
+        return $noErrors;
+    }
+
+    /**
+     * Check whether or not a filename has already been imported in a given process.
+     *
+     * @param string $filePath
+     */
+    private function isRecursiveImport($filePath)
+    {
+        if (in_array($filePath, self::$configImports))
+        {
+            throw new RecursiveConfigurationException($filePath, sprintf(
+                'The %s file has already been imported', $filePath
+            ));
+        }
+
+        self::$configImports[] = $filePath;
+    }
+
+    /**
+     * Merge the given array with existing configuration.
+     *
+     * @param  array $importedConfig
+     * @param  array $existingConfig
+     *
+     * @return array
+     */
+    private function mergeImports(array $importedConfig, array $existingConfig)
+    {
+        $arraySplit = ArrayUtilities::associative_array_split(self::IMPORT_KEYWORD, $existingConfig, false);
+        $beforeImport = ArrayUtilities::array_merge_defaults($arraySplit[0], $importedConfig, 'name');
+        $result = ArrayUtilities::array_merge_defaults($beforeImport, $arraySplit[1], 'name');
+
+        return $result;
     }
 }

--- a/src/allejo/stakx/Exception/FileAccessDeniedException.php
+++ b/src/allejo/stakx/Exception/FileAccessDeniedException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Exception;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+
+class FileAccessDeniedException extends IOException
+{
+
+}

--- a/src/allejo/stakx/Exception/RecursiveConfigurationException.php
+++ b/src/allejo/stakx/Exception/RecursiveConfigurationException.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Exception;
+
+use Exception;
+
+class RecursiveConfigurationException extends \RuntimeException
+{
+    private $import;
+
+    public function __construct($import, $message = "", $code = 0, Exception $previous = null)
+    {
+        $this->import = $import;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getRecursiveImport()
+    {
+        return $this->import;
+    }
+}

--- a/src/allejo/stakx/Utilities/ArrayUtilities.php
+++ b/src/allejo/stakx/Utilities/ArrayUtilities.php
@@ -68,4 +68,22 @@ abstract class ArrayUtilities
 
         return $merged;
     }
+
+    /**
+     * @param  string $key
+     * @param  array  $array
+     * @param  bool   $considerOffset
+     *
+     * @return array
+     */
+    public static function associative_array_split($key, array &$array, $considerOffset = true)
+    {
+        $offset = array_search($key, array_keys($array)) + (int)$considerOffset;
+        $result = array();
+
+        $result[0] = array_slice($array, 0 , $offset, true);
+        $result[1] = array_slice($array, $offset, null, true);
+
+        return $result;
+    }
 }

--- a/src/allejo/stakx/Utilities/StrUtils.php
+++ b/src/allejo/stakx/Utilities/StrUtils.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Utilities;
+
+class StrUtils
+{
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @author PHP Framework Interoperability Group
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return string
+     */
+    public static function interpolate($message, array $context)
+    {
+        // build a replacement array with braces around the context keys
+        $replace = array();
+
+        foreach ($context as $key => $val)
+        {
+            if (!is_array($val) && (!is_object($val) || method_exists($val, '__toString')))
+            {
+                $replace[sprintf('{%s}', $key)] = $val;
+            }
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr($message, $replace);
+    }
+}

--- a/src/allejo/stakx/Website.php
+++ b/src/allejo/stakx/Website.php
@@ -287,7 +287,7 @@ class Website
 
         $this->configuration = new Configuration();
         $this->configuration->setLogger($this->output);
-        $this->configuration->parseConfiguration($configFile);
+        $this->configuration->parse($configFile);
     }
 
     /**

--- a/tests/allejo/stakx/Test/CompilerTest.php
+++ b/tests/allejo/stakx/Test/CompilerTest.php
@@ -34,7 +34,8 @@ class CompilerTest extends PHPUnit_Stakx_TestCase
         ));
 
         $config = new Configuration();
-        $config->parseConfiguration();
+        $config->setLogger($this->getMockLogger());
+        $config->parse();
 
         $twigEnv = new TwigManager();
         $twigEnv->configureTwig($config, array(

--- a/tests/allejo/stakx/Test/ConfigurationTest.php
+++ b/tests/allejo/stakx/Test/ConfigurationTest.php
@@ -8,9 +8,8 @@
 namespace allejo\stakx\Test;
 
 use allejo\stakx\Configuration;
-use org\bovigo\vfs\vfsStream;
 
-class ConfigurationTests extends PHPUnit_Stakx_TestCase
+class ConfigurationTest extends PHPUnit_Stakx_TestCase
 {
     /**
      * @var Configuration
@@ -29,11 +28,22 @@ class ConfigurationTests extends PHPUnit_Stakx_TestCase
         $output = $this->getMockLogger();
         $this->sampleConfig = new Configuration();
         $this->sampleConfig->setLogger($output);
-        $this->sampleConfig->parseConfiguration(__DIR__ . '/assets/ConfigurationFiles/sample.yml');
+        $this->sampleConfig->parse(__DIR__ . '/assets/ConfigurationFiles/sample.yml');
 
         $this->defaultConfig = new Configuration();
         $this->defaultConfig->setLogger($output);
-        $this->defaultConfig->parseConfiguration();
+        $this->defaultConfig->parse();
+
+        $this->createAssetFolder('ConfigurationTestAssets');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        StreamInterceptor::$output = '';
+
+        $this->fs->remove($this->assetFolder);
     }
 
     public function testSampleConfigIsDebug()
@@ -127,55 +137,319 @@ class ConfigurationTests extends PHPUnit_Stakx_TestCase
         $this->assertEquals('_site', $this->defaultConfig->getTargetFolder());
     }
 
-    public function testDeprecatedBase()
+    public function testInvalidConfigurationFails()
     {
-        $output = $this->getMockLogger();
-
-        $file = vfsStream::newFile('_config.yml');
-        $root = vfsStream::setup();
-
-        $file->setContent('base: /my-deprecated')
-             ->at($root);
+        $output = $this->getReadableLogger();
+        $configPath = $this->writeTempFile('_config.yml', "foo: bar\nfoo baz");
 
         $config = new Configuration();
         $config->setLogger($output);
-        $config->parseConfiguration($file->url());
+        $config->parse($configPath);
+
+        $this->assertStringContains('parsing failed...', StreamInterceptor::$output);
+    }
+
+    public static function dataProviderImportTests()
+    {
+        return array(
+            array(
+                array(
+                    'files' => array(
+                        'parent.yml' => '
+value_one: 1
+value_two: 2
+
+import:
+  - child.yml
+',
+                        'child.yml' => '
+value_one: 5
+',
+                    ),
+                    'keys' => array(
+                        'value_one' => 5,
+                    ),
+                ),
+            ),
+
+            array(
+                array(
+                    'files' => array(
+                        'child.yml' => '
+import:
+  - parent.yml
+
+value_one: 1
+value_two: 2
+',
+                        'parent.yml' => '
+value_one: 5
+',
+                    ),
+                    'keys' => array(
+                        'value_one' => 1,
+                    ),
+                ),
+            ),
+
+            array(
+                array(
+                    'files' => array(
+                        'parent.yml' => '
+import:
+  - child.yml
+
+data:
+  - _data
+',
+                        'child.yml' => '
+data:
+  - _calendar
+',
+                    ),
+                    'keys' => array(
+                        'data' => array('_calendar', '_data'),
+                    ),
+                ),
+            ),
+
+            array(
+                array(
+                    'files' => array(
+                        'parent.yml' => '
+data:
+  - _data
+
+import:
+  - child.yml
+',
+                        'child.yml' => '
+data:
+  - _calendar
+',
+                    ),
+                    'keys' => array(
+                        'data' => array('_data', '_calendar'),
+                    ),
+                ),
+            ),
+
+            array(
+                array(
+                    'files' => array(
+                        'parent.yml' => '
+data:
+  - _data
+
+import:
+  - child.yml
+
+value_one: 100
+',
+                        'child.yml' => '
+data:
+  - _calendar
+
+value_one: 1
+',
+                    ),
+                    'keys' => array(
+                        'value_one' => 100
+                    ),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderImportTests
+     *
+     * @param array $rules
+     */
+    public function testConfigurationImports(array $rules)
+    {
+        $files = array();
+
+        foreach ($rules['files'] as $fileName => $fileContent)
+        {
+            $files[] = $this->writeTempFile($fileName, $fileContent);
+        }
+
+        $masterConfig = $files[0];
+
+        $config = new Configuration();
+        $config->setLogger($this->getMockLogger());
+        $config->parse($masterConfig);
+        $result = $config->getConfiguration();
+
+        $this->assertArrayNotHasKey('import', $result);
+
+        foreach ($rules['keys'] as $key => $expectedValue)
+        {
+            $this->assertEquals($expectedValue, $result[$key]);
+        }
+    }
+
+    public function testConfigurationImportDirectoryFails()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - hello/");
+        $this->writeTempFile('hello/world.yml', 'dummy file');
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains("can't import a directory", StreamInterceptor::$output);
+    }
+
+    public function testConfigurationImportSelfFails()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - _config.yml");
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains("can't import yourself", StreamInterceptor::$output);
+    }
+
+    public function testConfigurationImportNonYamlFails()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - my_xml.xml");
+        $this->writeTempFile('my_xml.xml', '<root></root>');
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains('a non-YAML configuration', StreamInterceptor::$output);
+    }
+
+    public function testConfigurationImportSymlinkFails()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - my_sym.yml");
+        $this->writeTempFile('original_file.yml', 'value: one');
+        $this->fs->symlink(
+            $this->fs->appendPath($this->assetFolder, 'original_file.yml'),
+            $this->fs->appendPath($this->assetFolder, 'my_sym.yml')
+        );
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains('a symbolically linked file', StreamInterceptor::$output);
+    }
+
+    public function testConfigurationImportFileNotFound()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - fake_file.yml");
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains('could not find file to import', StreamInterceptor::$output);
+    }
+
+    public function testConfigurationImportGrandchild()
+    {
+        $masterConfig = $this->writeTempFile('grandparent.yml', "import:\n  - parent.yml\ngrandparent_value: 1");
+        $this->writeTempFile('parent.yml', "import:\n  - child.yml\nparent_value: 2");
+        $this->writeTempFile('child.yml', 'child_value: 3');
+
+        $config = new Configuration();
+        $config->setLogger($this->getMockLogger());
+        $config->parse($masterConfig);
+        $result = $config->getConfiguration();
+
+        $this->assertArrayHasKey('grandparent_value', $result);
+        $this->assertArrayHasKey('parent_value', $result);
+        $this->assertArrayHasKey('child_value', $result);
+    }
+
+    public function testConfigurationImportRecursivelyFails()
+    {
+        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - _second.yml");
+        $this->writeTempFile('_second.yml', "import:\n  - _config.yml");
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($masterConfig);
+
+        $this->assertContains("can't recursively import a file", StreamInterceptor::$output);
+    }
+
+    public static function dataProviderInvalidImportArrays()
+    {
+        return array(
+            array("import:\n- 1"),
+            array("import:\n- true"),
+            array("import:\n- 2017-01-01"),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidImportArrays
+     *
+     * @param string $invalidImportArray
+     */
+    public function testConfigurationInvalidImportArrayFails($invalidImportArray)
+    {
+        $configPath = $this->writeTempFile('config.yml', $invalidImportArray);
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($configPath);
+
+        $this->assertContains('invalid import:', StreamInterceptor::$output);
+    }
+
+    public static function dataProviderInvalidImports()
+    {
+        return array(
+            array('import: true'),
+            array('import: ~'),
+            array('import: 1234'),
+            array('import: butter & toast'),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderInvalidImports
+     *
+     * @param string $invalidImport
+     */
+    public function testConfigurationImportNotAnArray($invalidImport)
+    {
+        $configPath = $this->writeTempFile('config.yml', $invalidImport);
+
+        $config = new Configuration();
+        $config->setLogger($this->getReadableLogger());
+        $config->parse($configPath);
+
+        $this->assertContains('the reserved "import" keyword can only be an array', StreamInterceptor::$output);
+    }
+
+    public function testDeprecatedBase()
+    {
+        $configPath = $this->writeTempFile('_config.yml', 'base: /my-deprecated');
+
+        $config = new Configuration();
+        $config->setLogger($this->getMockLogger());
+        $config->parse($configPath);
 
         $this->assertEquals('/my-deprecated', $config->getBaseUrl());
     }
 
     public function testDeprecatedBasePriority()
     {
-        $output = $this->getMockLogger();
-
-        $file = vfsStream::newFile('_config.yml');
-        $root = vfsStream::setup();
-
-        $file->setContent("base: /my-deprecated\nbaseurl: /my-new")
-            ->at($root);
+        $configPath = $this->writeTempFile('_config.yml', "base: /my-deprecated\nbaseurl: /my-new");
 
         $config = new Configuration();
-        $config->setLogger($output);
-        $config->parseConfiguration($file->url());
+        $config->setLogger($this->getMockLogger());
+        $config->parse($configPath);
 
         $this->assertEquals('/my-new', $config->getBaseUrl());
-    }
-
-    public function testInvalidConfigFile()
-    {
-        $output = $this->getMockLogger();
-
-        $file = vfsStream::newFile('_config.yml');
-        $root = vfsStream::setup();
-
-        $file->setContent('invalid yaml')
-             ->at($root);
-
-        $config = new Configuration($file->url(), $output);
-        $config->setLogger($output);
-        $config->parseConfiguration();
-
-        // This is part of the default configuration, so we should expect it here
-        $this->assertEquals('_site', $config->getTargetFolder());
     }
 }

--- a/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
+++ b/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
@@ -10,6 +10,7 @@ namespace allejo\stakx\Test;
 use allejo\stakx\Core\StakxLogger;
 use allejo\stakx\Manager\CollectionManager;
 use allejo\stakx\System\Filesystem;
+use allejo\stakx\System\Folder;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
@@ -20,6 +21,9 @@ use Symfony\Component\Yaml\Yaml;
 abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
 {
     const FM_OBJ_TEMPLATE = "---\n%s\n---\n\n%s";
+
+    /** @var string */
+    protected $assetFolder;
 
     /**
      * @var vfsStreamFile
@@ -64,9 +68,9 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         $this->assertStringContains($fileContent, $contents, $message);
     }
 
-    //
+    ///
     // Utility Functions
-    //
+    ///
 
     protected function bookCollectionProvider($jailed = false)
     {
@@ -155,5 +159,35 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         $fm = (empty($frontMatter)) ? '' : Yaml::dump($frontMatter, 2);
 
         return sprintf(self::FM_OBJ_TEMPLATE, $fm, $body);
+    }
+
+    /**
+     * Create a temporary folder where temporary file writes will be made to
+     *
+     * Remember to remove the folder in during the ::tearDown()
+     *
+     * @param string $folderName
+     */
+    protected function createAssetFolder($folderName)
+    {
+        $this->assetFolder = $this->fs->getRelativePath($this->fs->appendPath(__DIR__, $folderName));
+
+        $this->fs->mkdir($this->assetFolder);
+    }
+
+    /**
+     * Write a temporary file to the asset folder
+     *
+     * @param $fileName
+     * @param $content
+     *
+     * @return string Path to the temporary file; relative to the project's root
+     */
+    protected function writeTempFile($fileName, $content)
+    {
+        $folder = new Folder($this->assetFolder);
+        $folder->writeFile($fileName, $content);
+
+        return $this->fs->appendPath($this->assetFolder, $fileName);
     }
 }


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | #32 

### Description

Adds new `import` keyword to `_config.yml` to allow importing of other YAML files to different build environments/options.

- Make use of Filesystem::safeReadFile() to ensure only files within the website are being read/accessed


### Check List

- [x] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
