### PR TITLE
Add support for drafts w/ `draft: true`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ _site
 *.phar*
 .travis/phar-deploy.pem
 .php_cs.cache
+.php-version

--- a/example/_posts/2016-03-04-An-unpublished-post.md
+++ b/example/_posts/2016-03-04-An-unpublished-post.md
@@ -1,0 +1,9 @@
+---
+title: Something Super Awesome
+date: 2016-03-04
+draft: true
+---
+
+I'm in the process of writing this super awesome post about something very exciting but because it's still a work in progress, I'm marking this file as a draft by specifying `draft: true` in the FrontMatter. This will work for ContentItems, and not just "blog posts."
+
+During the build process, you can use the `--use-drafts` option to build the stakx website with drafts.

--- a/src/allejo/stakx/Compiler.php
+++ b/src/allejo/stakx/Compiler.php
@@ -7,6 +7,7 @@
 
 namespace allejo\stakx;
 
+use allejo\stakx\Command\BuildableCommand;
 use allejo\stakx\Document\ContentItem;
 use allejo\stakx\Document\DynamicPageView;
 use allejo\stakx\Document\PageView;
@@ -119,6 +120,11 @@ class Compiler extends BaseManager
      */
     private function compilePageView(&$pageView)
     {
+        $this->output->debug('Compiling {type} PageView: {pageview}', array(
+            'pageview' => $pageView->getRelativeFilePath(),
+            'type' => $pageView->getType()
+        ));
+
         switch ($pageView->getType())
         {
             case PageView::STATIC_TYPE:
@@ -168,6 +174,15 @@ class Compiler extends BaseManager
 
         foreach ($contentItems as &$contentItem)
         {
+            if ($contentItem->isDraft() && !Service::getParameter(BuildableCommand::USE_DRAFTS))
+            {
+                $this->output->debug('{file}: marked as a draft', array(
+                    'file' => $contentItem->getRelativeFilePath()
+                ));
+
+                continue;
+            }
+
             $targetFile = $contentItem->getTargetFile();
             $output = $this->renderDynamicPageView($template, $pageView, $contentItem);
 

--- a/src/allejo/stakx/Document/ContentItem.php
+++ b/src/allejo/stakx/Document/ContentItem.php
@@ -35,7 +35,7 @@ class ContentItem extends Document implements \JsonSerializable
     public function createJail()
     {
         return new JailedDocument($this, array_merge(self::$whiteListFunctions, array(
-            'getCollection',
+            'getCollection', 'isDraft'
         )), array('getPageView' => 'getJailedPageView'));
     }
 
@@ -104,6 +104,16 @@ class ContentItem extends Document implements \JsonSerializable
         }
 
         $this->bodyContent = $pd->parse($this->bodyContent);
+    }
+
+    /**
+     * Check whether a ContentItem should be treated as a draft
+     *
+     * @return bool
+     */
+    public function isDraft()
+    {
+        return ($this['draft'] === true);
     }
 
     /**

--- a/src/allejo/stakx/Document/PageView.php
+++ b/src/allejo/stakx/Document/PageView.php
@@ -16,9 +16,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class PageView extends Document
 {
-    const REPEATER_TYPE = 0;
-    const DYNAMIC_TYPE = 1;
-    const STATIC_TYPE = 2;
+    const REPEATER_TYPE = 'repeater';
+    const DYNAMIC_TYPE = 'dynamic';
+    const STATIC_TYPE = 'static';
 
     /**
      * @var Filesystem

--- a/src/allejo/stakx/Manager/CollectionManager.php
+++ b/src/allejo/stakx/Manager/CollectionManager.php
@@ -7,9 +7,11 @@
 
 namespace allejo\stakx\Manager;
 
+use allejo\stakx\Command\BuildableCommand;
 use allejo\stakx\Document\ContentItem;
 use allejo\stakx\Document\JailedDocument;
 use allejo\stakx\Exception\TrackedItemNotFoundException;
+use allejo\stakx\Service;
 
 /**
  * The class that reads and saves information about all of the collections.
@@ -61,12 +63,15 @@ class CollectionManager extends TrackingManager
     {
         $jailItems = array();
 
-        foreach ($this->trackedItems as $key => $items)
+        /**
+         * @var string      $key
+         * @var ContentItem $item
+         */
+        foreach ($this->trackedItemsFlattened as &$item)
         {
-            foreach ($items as $name => $contentItem)
-            {
-                $jailItems[$key][$name] = $contentItem->createJail();
-            }
+            if (!Service::getParameter(BuildableCommand::USE_DRAFTS) && $item['draft']) { continue; }
+
+            $jailItems[$item->getCollection()][$item->getName()] = $item->createJail();
         }
 
         return $jailItems;

--- a/src/allejo/stakx/Service.php
+++ b/src/allejo/stakx/Service.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx;
+
+abstract class Service
+{
+    protected static $parameters;
+
+    public static function getParameter($key)
+    {
+        return self::$parameters[$key];
+    }
+
+    public static function setParameter($key, $value)
+    {
+        self::$parameters[$key] = $value;
+    }
+}

--- a/tests/allejo/stakx/Test/Document/ContentItemTest.php
+++ b/tests/allejo/stakx/Test/Document/ContentItemTest.php
@@ -30,6 +30,15 @@ class ContentItemTests extends PHPUnit_Stakx_TestCase
         $this->assertEquals($this->dummyFile->url(), $contentItem->getFilePath());
     }
 
+    public function testContentItemAppearsAsDraft()
+    {
+        $item = $this->createContentItem(array(
+            'draft' => true
+        ));
+
+        $this->assertTrue($item->isDraft());
+    }
+
     public function testContentItemWithEmptyFrontMatter()
     {
         $item = $this->createContentItemWithEmptyFrontMatter();
@@ -37,7 +46,7 @@ class ContentItemTests extends PHPUnit_Stakx_TestCase
         $this->assertEmpty($item->getFrontMatter());
     }
 
-    public function testContentItemWitValidFrontMatter()
+    public function testContentItemWithValidFrontMatter()
     {
         $frontMatter = array(
             'string' => 'foo',

--- a/tests/allejo/stakx/Test/Manager/CollectionManagerTest.php
+++ b/tests/allejo/stakx/Test/Manager/CollectionManagerTest.php
@@ -7,7 +7,9 @@
 
 namespace allejo\stakx\Test\Manager;
 
+use allejo\stakx\Command\BuildableCommand;
 use allejo\stakx\Manager\CollectionManager;
+use allejo\stakx\Service;
 use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
 
 class CollectionManagerTests extends PHPUnit_Stakx_TestCase
@@ -66,5 +68,16 @@ class CollectionManagerTests extends PHPUnit_Stakx_TestCase
         $this->assertNotNull($contentItem);
         $this->assertEquals('My Books', $contentItem->getCollection());
         $this->assertEquals('0763680877', $contentItem['isbn_10']);
+    }
+
+    public function testCollectionManagerHasDrafts()
+    {
+        $withoutDrafts = count($this->cm->getJailedCollections()['My Books']);
+
+        Service::setParameter(BuildableCommand::USE_DRAFTS, true);
+
+        $withDrafts = count($this->cm->getJailedCollections()['My Books']);
+
+        $this->assertGreaterThan($withoutDrafts, $withDrafts);
     }
 }

--- a/tests/allejo/stakx/Test/Manager/PageManagerTest.php
+++ b/tests/allejo/stakx/Test/Manager/PageManagerTest.php
@@ -132,7 +132,8 @@ class PageManagerTest extends PHPUnit_Stakx_TestCase
         /** @var DynamicPageView $pageView */
         $pageView = current($pageViews);
 
-        $this->assertCount(5, $pageView->getContentItems());
+        $originalCount = count($pageView->getContentItems());
+        $this->assertGreaterThan(0, $originalCount);
 
         /** @var ContentItem $contentItem */
         $contentItem = $this->createVirtualFile(ContentItem::class);
@@ -140,7 +141,7 @@ class PageManagerTest extends PHPUnit_Stakx_TestCase
 
         $pageManager->trackNewContentItem($contentItem);
 
-        $this->assertCount(6, $pageView->getContentItems());
+        $this->assertCount($originalCount + 1, $pageView->getContentItems());
     }
 
     public function testWarningThrownWhenPageViewFolderNotFound()

--- a/tests/allejo/stakx/Test/Twig/GroupByFilterTest.php
+++ b/tests/allejo/stakx/Test/Twig/GroupByFilterTest.php
@@ -54,12 +54,16 @@ class GroupByFilterTests extends PHPUnit_Stakx_TestCase
         $filter = new GroupByFilter();
         $grouped = $filter($books, 'publisher');
 
-        $this->assertCount(2, $grouped);
         $this->assertArrayHasKey('Candlewick', $grouped);
         $this->assertArrayHasKey('Random House Books for Young Readers', $grouped);
 
-        $this->assertCount(3, $grouped['Candlewick']);
-        $this->assertCount(2, $grouped['Random House Books for Young Readers']);
+        foreach ($grouped as $publisher => $books)
+        {
+            foreach ($books as $book)
+            {
+                $this->assertEquals($publisher, $book['publisher']);
+            }
+        }
     }
 
     public function testGroupByFilterBooleanFrontMatterKey()
@@ -68,11 +72,18 @@ class GroupByFilterTests extends PHPUnit_Stakx_TestCase
         $filter = new GroupByFilter();
         $grouped = $filter($books, 'completed');
 
-        $this->assertCount(2, $grouped);
         $this->assertArrayHasKey('true', $grouped);
         $this->assertArrayHasKey('false', $grouped);
-        $this->assertCount(3, $grouped['true']);
-        $this->assertCount(1, $grouped['false']);
+
+        foreach ($grouped['true'] as $item)
+        {
+            $this->assertTrue($item['completed']);
+        }
+
+        foreach ($grouped['false'] as $item)
+        {
+            $this->assertFalse($item['completed']);
+        }
     }
 
     public function testGroupByFilterNullFrontMatterKey()

--- a/tests/allejo/stakx/Test/Twig/OrderByFilterTest.php
+++ b/tests/allejo/stakx/Test/Twig/OrderByFilterTest.php
@@ -108,7 +108,8 @@ class OrderByFilterTest extends PHPUnit_Stakx_TestCase
         $results = $orderFilter($books, $sortKey);
         $lastCount = -1;
 
-        foreach ($results as $result) {
+        foreach ($results as $result)
+        {
             $this->assertGreaterThanOrEqual($lastCount, $result[$sortKey]);
             $lastCount = $result[$sortKey];
         }
@@ -126,7 +127,8 @@ class OrderByFilterTest extends PHPUnit_Stakx_TestCase
         $results = $orderFilter($books, $sortKey, 'DESC');
         $lastCount = 999999;
 
-        foreach ($results as $result) {
+        foreach ($results as $result)
+        {
             $this->assertLessThanOrEqual($lastCount, $result[$sortKey]);
             $lastCount = $result[$sortKey];
         }

--- a/tests/allejo/stakx/Test/Twig/WhereFilterTest.php
+++ b/tests/allejo/stakx/Test/Twig/WhereFilterTest.php
@@ -155,7 +155,7 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
     {
         return array(
             array('completed', '==', true, 3),
-            array('completed', '==', false, 1),
+            array('completed', '==', false, 2),
             array('completed', '==', null, 1),
             array('completed', '!=', false, 4),
             array('completed', '~=', false, 0),

--- a/tests/allejo/stakx/Test/assets/MyBookCollection/Unpublished-title.md
+++ b/tests/allejo/stakx/Test/assets/MyBookCollection/Unpublished-title.md
@@ -1,0 +1,17 @@
+---
+title: Unpublished Title
+age: 9 - 12 years
+grade: 4 - 7
+page_count: 0
+publisher: TBD
+language: English
+isbn_10: ~
+isbn_13: ~
+dimensions: ~
+shipping_weight: ~
+completed: false
+animals: ~
+draft: true
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum hendrerit tortor malesuada, convallis est sed, imperdiet elit. Nam enim dui, eleifend nec neque vel, fermentum elementum turpis. Sed sed nibh eget velit maximus elementum ut a metus. Nullam finibus facilisis dapibus. Maecenas commodo, nunc id pellentesque rutrum, enim mi ullamcorper enim, quis tempor neque nisl at lacus. Aliquam dapibus eget odio eget gravida. Proin laoreet faucibus quam, nec malesuada purus porta non. Quisque id ipsum at felis varius tristique eu eget odio. Pellentesque ac lacinia dui, quis faucibus est. Etiam at congue urna, a suscipit urna.


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | #44 

### Description

Introduce the ability to respect `draft: true` in the Front Matter of a Content Item to prevent it from being written to a file.

- [x] Add `--use-drafts` option
- [x] Drafts aren't available in the `collections` array in Twig

### Check List

- [x] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
