### PR TITLE
Allow datasets to be the iterator for a dynamic PageView

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectPlainTextFileTypeManager">
+    <file url="file://$PROJECT_DIR$/vendor/twig/twig/test/bootstrap.php" />
+  </component>
+</project>

--- a/.idea/stakx.iml
+++ b/.idea/stakx.iml
@@ -19,7 +19,7 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
-      <library name="PHP">
+      <library name="PHP" type="php">
         <CLASSES>
           <root url="file://$MODULE_DIR$/vendor/aptoma/twig-markdown" />
           <root url="file://$MODULE_DIR$/vendor/composer" />

--- a/example/_datasets/calendar/february.yml
+++ b/example/_datasets/calendar/february.yml
@@ -1,2 +1,2 @@
-- date: 2016-02-14
+- date: 2016-02-14 00:00:00.00 -8
   localName: Washington's Birthday

--- a/example/_datasets/calendar/january.yaml
+++ b/example/_datasets/calendar/january.yaml
@@ -1,4 +1,4 @@
 - date: 2016-01-01 00:00:00.00 -8
   localName: New Year's Day
-- date: 2016-01-18
+- date: 2016-01-18 00:00:00.00 -8
   localName: Birthday of Martin Luther King, Jr.

--- a/example/_datasets/calendar/july.yml
+++ b/example/_datasets/calendar/july.yml
@@ -1,2 +1,2 @@
-- date: 2016-07-04
+- date: 2016-07-04 00:00:00.00 -8
   localName: Independence Day

--- a/example/_datasets/calendar/may.yml
+++ b/example/_datasets/calendar/may.yml
@@ -1,2 +1,2 @@
-- date: 2016-05-30
+- date: 2016-05-30 00:00:00.00 -8
   localName: Memorial Day

--- a/example/_datasets/calendar/november.yml
+++ b/example/_datasets/calendar/november.yml
@@ -1,4 +1,4 @@
-- date: 2016-11-11
+- date: 2016-11-11 00:00:00.00 -8
   localName: Veterans' Day
-- date: 2016-11-24
+- date: 2016-11-24 00:00:00.00 -8
   localName: Thanksgiving Day

--- a/example/_datasets/calendar/october.yml
+++ b/example/_datasets/calendar/october.yml
@@ -1,2 +1,2 @@
-- date: 2016-10-10
+- date: 2016-10-10 00:00:00.00 -8
   localName: Columbus Day

--- a/example/_datasets/calendar/september.yml
+++ b/example/_datasets/calendar/september.yml
@@ -1,2 +1,2 @@
-- date: 2016-09-05
+- date: 2016-09-05 00:00:00.00 -8
   localName: Labor Day

--- a/example/_pages/calendar/list.html.twig
+++ b/example/_pages/calendar/list.html.twig
@@ -15,7 +15,7 @@ permalink:
         <thead>
             <tr>
                 <th colspan="7" class="c-calendar__month">
-                    {{ month }}
+                    <a href="{{ url('/calendar/' ~ (month | lower)) }}">{{ month }}</a>
                 </th>
             </tr>
             <tr>

--- a/example/_pages/calendar/show.html.twig
+++ b/example/_pages/calendar/show.html.twig
@@ -1,0 +1,15 @@
+---
+permalink: /calendar/%basename/
+dataset: calendar
+---
+
+{% extends "_layouts/base.html.twig" %}
+
+{% block content %}
+    {% for date in this %}
+        <article>
+            <p><strong>{{ date.localName }}</strong></p>
+            <p>{{ date.date | date('F d, Y') }}</p>
+        </article>
+    {% endfor %}
+{% endblock %}

--- a/src/allejo/stakx/Document/ContentItem.php
+++ b/src/allejo/stakx/Document/ContentItem.php
@@ -10,10 +10,10 @@ namespace allejo\stakx\Document;
 use allejo\stakx\Engines\Markdown\MarkdownEngine;
 use allejo\stakx\Engines\PlainTextEngine;
 use allejo\stakx\Engines\RST\RstEngine;
-use allejo\stakx\FrontMatter\Document;
+use allejo\stakx\FrontMatter\FrontMatterDocument;
 use allejo\stakx\Manager\TwigManager;
 
-class ContentItem extends Document implements \JsonSerializable
+class ContentItem extends FrontMatterDocument implements \JsonSerializable, \IteratorAggregate, TwigDocumentInterface
 {
     /**
      * The collection this Content Item belongs to.
@@ -149,5 +149,10 @@ class ContentItem extends Document implements \JsonSerializable
             'permalink' => $this->getPermalink(),
             'redirects' => $this->getRedirects(),
         ));
+    }
+
+    public function getIterator()
+    {
+        return (new \ArrayIterator($this->frontMatter));
     }
 }

--- a/src/allejo/stakx/Document/ContentItem.php
+++ b/src/allejo/stakx/Document/ContentItem.php
@@ -39,12 +39,12 @@ class ContentItem extends FrontMatterDocument implements \JsonSerializable, \Ite
         )), array('getPageView' => 'getJailedPageView'));
     }
 
-    public function getCollection()
+    public function getNamespace()
     {
         return $this->parentCollection;
     }
 
-    public function setCollection($collection)
+    public function setNamespace($collection)
     {
         $this->parentCollection = $collection;
     }

--- a/src/allejo/stakx/Document/DataItem.php
+++ b/src/allejo/stakx/Document/DataItem.php
@@ -31,11 +31,6 @@ class DataItem extends PermalinkDocument implements
         parent::__construct($filePath);
     }
 
-    public function getIterator()
-    {
-        return new \ArrayIterator($this->data);
-    }
-
     public function getData()
     {
         return $this->data;
@@ -46,6 +41,9 @@ class DataItem extends PermalinkDocument implements
         return $this->getBaseName();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function evaluateFrontMatter($variables = array())
     {
         $workspace = array_merge($this->data, $variables);
@@ -74,65 +72,21 @@ class DataItem extends PermalinkDocument implements
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function buildPermalink()
     {
         return;
     }
 
     ///
-    // Jailed Document implementation
-    ///
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createJail()
-    {
-        return new JailedDocument($this, array(
-            'getExtension', 'getFilePath', 'getName', 'getRelativeFilePath'
-        ));
-    }
-
-    ///
-    // ArrayAccess implementation
-    ///
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->data[$offset]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetGet($offset)
-    {
-        return $this->data[$offset];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->data[$offset] = $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->data[$offset]);
-    }
-
-    ///
     // Twig Document implementation
     ///
 
+    /**
+     * {@inheritdoc}
+     */
     public function getNamespace()
     {
         return $this->namespace;
@@ -154,11 +108,17 @@ class DataItem extends PermalinkDocument implements
         $this->pageView = &$pageView;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isDraft()
     {
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function refreshFileContent()
     {
         // This function can be called after the initial object was created and the file may have been deleted since the
@@ -173,6 +133,7 @@ class DataItem extends PermalinkDocument implements
 
         if (method_exists(get_called_class(), $fxnName))
         {
+            $this->handleDependencies($this->getExtension());
             $this->data = (null !== ($c = $this->$fxnName($content))) ? $c : array();
 
             return;
@@ -255,6 +216,8 @@ class DataItem extends PermalinkDocument implements
     }
 
     /**
+     * Check for any dependencies needed to parse for a specific file extension
+     *
      * @param string $extension
      *
      * @todo 0.1.0 Create a help page on the main stakx website for this topic and link to it
@@ -267,5 +230,64 @@ class DataItem extends PermalinkDocument implements
         {
             throw new DependencyMissingException('XML', 'XML support is not available with the current PHP installation.');
         }
+    }
+
+    ///
+    // Jailed Document implementation
+    ///
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createJail()
+    {
+        return new JailedDocument($this, array(
+            'getExtension', 'getFilePath', 'getName', 'getRelativeFilePath'
+        ));
+    }
+
+    ///
+    // IteratorAggregate implementation
+    ///
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
+    }
+
+    ///
+    // ArrayAccess implementation
+    ///
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
     }
 }

--- a/src/allejo/stakx/Document/DataItem.php
+++ b/src/allejo/stakx/Document/DataItem.php
@@ -1,0 +1,271 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Document;
+
+use allejo\stakx\Exception\DependencyMissingException;
+use allejo\stakx\Exception\UnsupportedDataTypeException;
+use allejo\stakx\FrontMatter\Parser;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Symfony\Component\Yaml\Yaml;
+
+class DataItem extends PermalinkDocument implements
+    \ArrayAccess,
+    \IteratorAggregate,
+    TwigDocumentInterface,
+    JailedDocumentInterface
+{
+    protected $data;
+
+    private $namespace;
+    private $pageView;
+
+    public function __construct($filePath)
+    {
+        $this->namespace = '';
+
+        parent::__construct($filePath);
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getName()
+    {
+        return $this->getBaseName();
+    }
+
+    public function evaluateFrontMatter($variables = array())
+    {
+        $workspace = array_merge($this->data, $variables);
+        $parser = new Parser($workspace, array(
+            'filename' => $this->getFileName(),
+            'basename' => $this->getBaseName(),
+        ));
+
+        if (!is_null($parser) && $parser->hasExpansion())
+        {
+            throw new \LogicException('The permalink for this item has not been set.');
+        }
+
+        $permalink = $workspace['permalink'];
+
+        if (is_array($permalink))
+        {
+            $this->permalink = $permalink[0];
+            array_shift($permalink);
+            $this->redirects = $permalink;
+        }
+        else
+        {
+            $this->permalink = $permalink;
+            $this->redirects = array();
+        }
+    }
+
+    protected function buildPermalink()
+    {
+        return;
+    }
+
+    ///
+    // Jailed Document implementation
+    ///
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createJail()
+    {
+        return new JailedDocument($this, array(
+            'getExtension', 'getFilePath', 'getName', 'getRelativeFilePath'
+        ));
+    }
+
+    ///
+    // ArrayAccess implementation
+    ///
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
+    ///
+    // Twig Document implementation
+    ///
+
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPageView(&$pageView)
+    {
+        $this->pageView = &$pageView;
+    }
+
+    public function isDraft()
+    {
+        return false;
+    }
+
+    public function refreshFileContent()
+    {
+        // This function can be called after the initial object was created and the file may have been deleted since the
+        // creation of the object.
+        if (!$this->fs->exists($this->filePath))
+        {
+            throw new FileNotFoundException(null, 0, null, $this->filePath);
+        }
+
+        $content = file_get_contents($this->getFilePath());
+        $fxnName = 'from' . ucfirst($this->getExtension());
+
+        if (method_exists(get_called_class(), $fxnName))
+        {
+            $this->data = (null !== ($c = $this->$fxnName($content))) ? $c : array();
+
+            return;
+        }
+
+        throw new UnsupportedDataTypeException($this->getExtension(), "There is no support to handle this file extension.");
+    }
+
+    ///
+    // File parsing helpers
+    ///
+
+    /**
+     * Convert from CSV into an associative array.
+     *
+     * @param string $content CSV formatted text
+     *
+     * @return array
+     */
+    private function fromCsv($content)
+    {
+        $rows = array_map('str_getcsv', explode("\n", trim($content)));
+        $columns = array_shift($rows);
+        $csv = array();
+
+        foreach ($rows as $row)
+        {
+            $csv[] = array_combine($columns, $row);
+        }
+
+        return $csv;
+    }
+
+    /**
+     * Convert from JSON into an associative array.
+     *
+     * @param string $content JSON formatted text
+     *
+     * @return array
+     */
+    private function fromJson($content)
+    {
+        return json_decode($content, true);
+    }
+
+    /**
+     * Convert from XML into an associative array.
+     *
+     * @param string $content XML formatted text
+     *
+     * @return array
+     */
+    private function fromXml($content)
+    {
+        return json_decode(json_encode(simplexml_load_string($content)), true);
+    }
+
+    /**
+     * Convert from YAML into an associative array.
+     *
+     * @param string $content YAML formatted text
+     *
+     * @return array
+     */
+    private function fromYaml($content)
+    {
+        return Yaml::parse($content, Yaml::PARSE_DATETIME);
+    }
+
+    /**
+     * An alias for handling `*.yml` files.
+     *
+     * @param string $content YAML formatted text
+     *
+     * @return array
+     */
+    private function fromYml($content)
+    {
+        return $this->fromYaml($content);
+    }
+
+    /**
+     * @param string $extension
+     *
+     * @todo 0.1.0 Create a help page on the main stakx website for this topic and link to it
+     *
+     * @throws DependencyMissingException
+     */
+    private function handleDependencies($extension)
+    {
+        if ($extension === 'xml' && !function_exists('simplexml_load_string'))
+        {
+            throw new DependencyMissingException('XML', 'XML support is not available with the current PHP installation.');
+        }
+    }
+}

--- a/src/allejo/stakx/Document/DynamicPageView.php
+++ b/src/allejo/stakx/Document/DynamicPageView.php
@@ -14,7 +14,7 @@ class DynamicPageView extends PageView
      *
      * @var ContentItem[]
      */
-    private $contentItems;
+    private $repeatableItems;
 
     /**
      * {@inheritdoc}
@@ -23,21 +23,21 @@ class DynamicPageView extends PageView
     {
         parent::__construct($filePath);
 
-        $this->contentItems = array();
+        $this->repeatableItems = array();
         $this->type = PageView::DYNAMIC_TYPE;
     }
 
     /**
      * Add a ContentItem to this Dynamic PageView.
      *
-     * @param ContentItem $contentItem
+     * @param TwigDocumentInterface $repeatableItem
      */
-    public function addContentItem(&$contentItem)
+    public function addRepeatableItem(&$repeatableItem)
     {
-        $filename = $this->fs->getBaseName($contentItem->getFilePath());
+        $filename = $this->fs->getBaseName($repeatableItem->getFilePath());
 
-        $this->contentItems[$filename] = &$contentItem;
-        $contentItem->setPageView($this);
+        $this->repeatableItems[$filename] = &$repeatableItem;
+        $repeatableItem->setPageView($this);
     }
 
     /**
@@ -45,9 +45,9 @@ class DynamicPageView extends PageView
      *
      * @return ContentItem[]
      */
-    public function getContentItems()
+    public function getRepeatableItems()
     {
-        return $this->contentItems;
+        return $this->repeatableItems;
     }
 
     /**
@@ -58,5 +58,27 @@ class DynamicPageView extends PageView
     public function getCollection()
     {
         return $this->getFrontMatter(false)['collection'];
+    }
+
+    /**
+     * Get the dataset name this dynamic PageView is charged with.
+     *
+     * @return string
+     */
+    public function getDataset()
+    {
+        return $this->getFrontMatter(false)['dataset'];
+    }
+
+    public function getRepeatableName()
+    {
+        $fm = $this->getFrontMatter(false);
+
+        if (isset($fm['collection']))
+        {
+            return $fm['collection'];
+        }
+
+        return $fm['dataset'];
     }
 }

--- a/src/allejo/stakx/Document/JailedDocument.php
+++ b/src/allejo/stakx/Document/JailedDocument.php
@@ -13,7 +13,7 @@ namespace allejo\stakx\Document;
  * A wrapper object to only allow certain functions on the white list to be called. This is used in order to limit which
  * functions a user can call from Twig templates to prevent unexpected behavior.
  */
-class JailedDocument implements \ArrayAccess
+class JailedDocument implements \ArrayAccess, \IteratorAggregate
 {
     /**
      * @var string[]
@@ -39,7 +39,9 @@ class JailedDocument implements \ArrayAccess
      */
     public function __construct(&$object, array $whiteListFunctions, array $jailedFunctions = array())
     {
-        if (!($object instanceof JailedDocumentInterface) && !($object instanceof \ArrayAccess))
+        if (!($object instanceof JailedDocumentInterface) &&
+            !($object instanceof \ArrayAccess) &&
+            !($object instanceof \IteratorAggregate))
         {
             throw new \InvalidArgumentException('Must implement the ArrayAccess and Jailable interfaces');
         }
@@ -111,5 +113,17 @@ class JailedDocument implements \ArrayAccess
     public function offsetUnset($offset)
     {
         return $this->object->offsetUnset($offset);
+    }
+
+    //
+    // IteratorAggregate implementation
+    //
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return $this->object->getIterator();
     }
 }

--- a/src/allejo/stakx/Document/JailedDocumentInterface.php
+++ b/src/allejo/stakx/Document/JailedDocumentInterface.php
@@ -15,7 +15,7 @@ namespace allejo\stakx\Document;
 interface JailedDocumentInterface
 {
     /**
-     * Create a JailObject instance from the object implementing this interface.
+     * Create a JailDocument instance from the object implementing this interface.
      *
      * @return JailedDocument
      */

--- a/src/allejo/stakx/Document/PageView.php
+++ b/src/allejo/stakx/Document/PageView.php
@@ -7,14 +7,14 @@
 
 namespace allejo\stakx\Document;
 
-use allejo\stakx\FrontMatter\Document;
+use allejo\stakx\FrontMatter\FrontMatterDocument;
 use allejo\stakx\System\Filesystem;
 use allejo\stakx\System\StakxResource;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Symfony\Component\Yaml\Yaml;
 
-class PageView extends Document
+class PageView extends FrontMatterDocument
 {
     const REPEATER_TYPE = 'repeater';
     const DYNAMIC_TYPE = 'dynamic';

--- a/src/allejo/stakx/Document/PageView.php
+++ b/src/allejo/stakx/Document/PageView.php
@@ -144,8 +144,9 @@ class PageView extends FrontMatterDocument
     {
         $instance = new self($filePath);
 
-        if (isset($instance->getFrontMatter(false)['collection']))
-        {
+        if (isset($instance->getFrontMatter(false)['collection']) ||
+            isset($instance->getFrontMatter(false)['dataset'])
+        ) {
             return new DynamicPageView($filePath);
         }
 

--- a/src/allejo/stakx/Document/PermalinkDocument.php
+++ b/src/allejo/stakx/Document/PermalinkDocument.php
@@ -9,7 +9,10 @@ namespace allejo\stakx\Document;
 
 abstract class PermalinkDocument extends ReadableDocument
 {
+    /** @var array */
     protected $permalink;
+
+    /** @var array */
     protected $redirects;
 
     /**
@@ -129,6 +132,18 @@ abstract class PermalinkDocument extends ReadableDocument
 
         return $permalink;
     }
+
+    /**
+     * Evaluate the FrontMatter for the document.
+     *
+     * This FrontMatter can be the user-defined FrontMatter in a FrontMatterDocument but it can also be used as internal
+     * settings used for objects that do not have user-defined FrontMatter such as DataItems.
+     *
+     * @param array $variables
+     *
+     * @return void
+     */
+    abstract public function evaluateFrontMatter($variables = array());
 
     /**
      * @return void

--- a/src/allejo/stakx/Document/PermalinkDocument.php
+++ b/src/allejo/stakx/Document/PermalinkDocument.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Document;
+
+abstract class PermalinkDocument extends ReadableDocument
+{
+    protected $permalink;
+    protected $redirects;
+
+    /**
+     * Get the destination of where this Content Item would be written to when the website is compiled.
+     *
+     * @return string
+     */
+    final public function getTargetFile()
+    {
+        $permalink = $this->getPermalink();
+        $missingFile = (substr($permalink, -1) == '/');
+        $permalink = str_replace('/', DIRECTORY_SEPARATOR, $permalink);
+
+        if ($missingFile)
+        {
+            $permalink = rtrim($permalink, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'index.html';
+        }
+
+        return ltrim($permalink, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Get the permalink of this Content Item.
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    final public function getPermalink()
+    {
+        $this->buildPermalink();
+
+        $this->permalink = $this->sanitizePermalink($this->permalink);
+        $this->permalink = str_replace(DIRECTORY_SEPARATOR, '/', $this->permalink);
+        $this->permalink = '/' . ltrim($this->permalink, '/'); // Permalinks should always use '/' and not be OS specific
+
+        return $this->permalink;
+    }
+
+    /**
+     * Get an array of URLs that will redirect to.
+     *
+     * @return string[]
+     */
+    final public function getRedirects()
+    {
+        if (is_null($this->redirects))
+        {
+            $this->getPermalink();
+        }
+
+        return $this->redirects;
+    }
+
+    /**
+     * Get the permalink based off the location of where the file is relative to the website. This permalink is to be
+     * used as a fallback in the case that a permalink is not explicitly specified in the Front Matter.
+     *
+     * @return string
+     */
+    protected function getPathPermalink()
+    {
+        // Remove the protocol of the path, if there is one and prepend a '/' to the beginning
+        $cleanPath = preg_replace('/[\w|\d]+:\/\//', '', $this->getRelativeFilePath());
+        $cleanPath = ltrim($cleanPath, DIRECTORY_SEPARATOR);
+
+        // Handle vfs:// paths by replacing their forward slashes with the OS appropriate directory separator
+        if (DIRECTORY_SEPARATOR !== '/')
+        {
+            $cleanPath = str_replace('/', DIRECTORY_SEPARATOR, $cleanPath);
+        }
+
+        // Check the first folder and see if it's a data folder (starts with an underscore) intended for stakx
+        $folders = explode(DIRECTORY_SEPARATOR, $cleanPath);
+
+        if (substr($folders[0], 0, 1) === '_')
+        {
+            array_shift($folders);
+        }
+
+        $cleanPath = implode(DIRECTORY_SEPARATOR, $folders);
+
+        return $cleanPath;
+    }
+
+    /**
+     * Sanitize a permalink to remove unsupported characters or multiple '/' and replace spaces with hyphens.
+     *
+     * @param string $permalink A permalink
+     *
+     * @return string $permalink The sanitized permalink
+     */
+    protected function sanitizePermalink($permalink)
+    {
+        // Remove multiple '/' together
+        $permalink = preg_replace('/\/+/', '/', $permalink);
+
+        // Replace all spaces with hyphens
+        $permalink = str_replace(' ', '-', $permalink);
+
+        // Remove all disallowed characters
+        $permalink = preg_replace('/[^0-9a-zA-Z-_\/\\\.]/', '', $permalink);
+
+        // Handle unnecessary extensions
+        $extensionsToStrip = array('twig');
+
+        if (in_array($this->fs->getExtension($permalink), $extensionsToStrip))
+        {
+            $permalink = $this->fs->removeExtension($permalink);
+        }
+
+        // Remove any special characters before a sane value
+        $permalink = preg_replace('/^[^0-9a-zA-Z-_]*/', '', $permalink);
+
+        // Convert permalinks to lower case
+        $permalink = mb_strtolower($permalink, 'UTF-8');
+
+        return $permalink;
+    }
+
+    /**
+     * @return void
+     */
+    abstract protected function buildPermalink();
+}

--- a/src/allejo/stakx/Document/ReadableDocument.php
+++ b/src/allejo/stakx/Document/ReadableDocument.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Document;
+
+use allejo\stakx\System\Filesystem;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+
+abstract class ReadableDocument
+{
+    protected $filePath;
+    protected $fs;
+
+    public function __construct($filePath)
+    {
+        $this->fs = new Filesystem();
+        $p = $this->filePath = $this->fs->absolutePath((string)$filePath);
+
+        if (!$this->fs->exists($p))
+        {
+            throw new FileNotFoundException("The following file could not be found: ${p}");
+        }
+
+        $this->extension = strtolower($this->fs->getExtension($p));
+
+        $this->refreshFileContent();
+    }
+
+    final public function getRelativeFilePath()
+    {
+        return $this->fs->getRelativePath($this->filePath);
+    }
+
+    final public function getExtension()
+    {
+        return $this->extension;
+    }
+
+    final public function getBaseName()
+    {
+        return $this->fs->getBaseName($this->filePath);
+    }
+
+    final public function getFilePath()
+    {
+        return $this->filePath;
+    }
+
+    final public function getFileName()
+    {
+        return $this->fs->getFileName($this->filePath);
+    }
+
+    abstract public function refreshFileContent();
+}

--- a/src/allejo/stakx/Document/ReadableDocument.php
+++ b/src/allejo/stakx/Document/ReadableDocument.php
@@ -13,6 +13,7 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 abstract class ReadableDocument
 {
     protected $filePath;
+    protected $extension;
     protected $fs;
 
     public function __construct($filePath)
@@ -20,13 +21,7 @@ abstract class ReadableDocument
         $this->fs = new Filesystem();
         $p = $this->filePath = $this->fs->absolutePath((string)$filePath);
 
-        if (!$this->fs->exists($p))
-        {
-            throw new FileNotFoundException("The following file could not be found: ${p}");
-        }
-
         $this->extension = strtolower($this->fs->getExtension($p));
-
         $this->refreshFileContent();
     }
 

--- a/src/allejo/stakx/Document/TwigDocumentInterface.php
+++ b/src/allejo/stakx/Document/TwigDocumentInterface.php
@@ -59,6 +59,11 @@ interface TwigDocumentInterface
     public function isDraft();
 
     /**
+     * Read the contents of a file.
+     *
+     * This function is responsible for reading the file and doing whatever is needed to parse & save the contents into
+     * the given object.
+     *
      * @return void
      */
     public function refreshFileContent();

--- a/src/allejo/stakx/Document/TwigDocumentInterface.php
+++ b/src/allejo/stakx/Document/TwigDocumentInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Document;
+
+interface TwigDocumentInterface
+{
+    /**
+     * @param string $filePath
+     */
+    public function __construct($filePath);
+
+    /**
+     * @return string
+     */
+    public function getNamespace();
+
+    /**
+     * @param string $namespace
+     *
+     * @return void
+     */
+    public function setNamespace($namespace);
+
+    /**
+     * @param PageView $pageView
+     *
+     * @return void
+     */
+    public function setPageView(&$pageView);
+
+    /**
+     * @return string
+     */
+    public function getRelativeFilePath();
+
+    /**
+     * @return string
+     */
+    public function getExtension();
+
+    /**
+     * @return string
+     */
+    public function getFilePath();
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @return bool
+     */
+    public function isDraft();
+
+    /**
+     * @return void
+     */
+    public function refreshFileContent();
+}

--- a/src/allejo/stakx/Exception/DataSetNotFoundException.php
+++ b/src/allejo/stakx/Exception/DataSetNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Exception;
+
+class DataSetNotFoundException extends \RuntimeException
+{
+}

--- a/src/allejo/stakx/Exception/UnsupportedDataTypeException.php
+++ b/src/allejo/stakx/Exception/UnsupportedDataTypeException.php
@@ -9,13 +9,13 @@ namespace allejo\stakx\Exception;
 
 use Throwable;
 
-class DependencyMissingException extends \RuntimeException
+class UnsupportedDataTypeException extends \RuntimeException
 {
-    private $dependency;
+    private $dataType;
 
-    public function __construct($dependency, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct($dataType, $message = "", $code = 0, Throwable $previous = null)
     {
-        $this->dependency = $dependency;
+        $this->dataType = $dataType;
 
         parent::__construct($message, $code, $previous);
     }
@@ -23,8 +23,8 @@ class DependencyMissingException extends \RuntimeException
     /**
      * @return string
      */
-    public function getDependency()
+    public function getDataType()
     {
-        return $this->dependency;
+        return $this->dataType;
     }
 }

--- a/src/allejo/stakx/Manager/CollectionManager.php
+++ b/src/allejo/stakx/Manager/CollectionManager.php
@@ -61,20 +61,7 @@ class CollectionManager extends TrackingManager
      */
     public function getJailedCollections()
     {
-        $jailItems = array();
-
-        /**
-         * @var string      $key
-         * @var ContentItem $item
-         */
-        foreach ($this->trackedItemsFlattened as &$item)
-        {
-            if (!Service::getParameter(BuildableCommand::USE_DRAFTS) && $item['draft']) { continue; }
-
-            $jailItems[$item->getNamespace()][$item->getName()] = $item->createJail();
-        }
-
-        return $jailItems;
+        return $this->getJailedTrackedItems();
     }
 
     /**

--- a/src/allejo/stakx/Manager/CollectionManager.php
+++ b/src/allejo/stakx/Manager/CollectionManager.php
@@ -71,7 +71,7 @@ class CollectionManager extends TrackingManager
         {
             if (!Service::getParameter(BuildableCommand::USE_DRAFTS) && $item['draft']) { continue; }
 
-            $jailItems[$item->getCollection()][$item->getName()] = $item->createJail();
+            $jailItems[$item->getNamespace()][$item->getName()] = $item->createJail();
         }
 
         return $jailItems;
@@ -147,7 +147,7 @@ class CollectionManager extends TrackingManager
         $collectionName = $options['namespace'];
 
         $contentItem = new ContentItem($filePath);
-        $contentItem->setCollection($collectionName);
+        $contentItem->setNamespace($collectionName);
 
         $this->addObjectToTracker($contentItem, $contentItem->getName(), $collectionName);
 

--- a/src/allejo/stakx/Manager/DataManager.php
+++ b/src/allejo/stakx/Manager/DataManager.php
@@ -35,6 +35,11 @@ class DataManager extends TrackingManager
         return $this->trackedItems;
     }
 
+    public function getJailedDataItems()
+    {
+        return $this->getJailedTrackedItems();
+    }
+
     /**
      * Loop through all of the DataItems specified in `$folders`. Each folder will have contain just DataItems.
      *

--- a/src/allejo/stakx/Manager/DataManager.php
+++ b/src/allejo/stakx/Manager/DataManager.php
@@ -8,7 +8,9 @@
 namespace allejo\stakx\Manager;
 
 use allejo\stakx\Exception\DependencyMissingException;
-use Symfony\Component\Yaml\Yaml;
+use allejo\stakx\Document\DataItem;
+use allejo\stakx\Exception\UnsupportedDataTypeException;
+use allejo\stakx\Utilities\StrUtils;
 
 /**
  * Class DataManager.
@@ -28,7 +30,7 @@ class DataManager extends TrackingManager
      *
      * @return array
      */
-    public function getDataItems()
+    public function &getDataItems()
     {
         return $this->trackedItems;
     }
@@ -100,115 +102,33 @@ class DataManager extends TrackingManager
      */
     protected function handleTrackableItem($filePath, $options = array())
     {
-        $relFilePath = $this->fs->getRelativePath($filePath);
-        $ext = strtolower($this->fs->getExtension($filePath));
-        $name = $this->fs->getBaseName($filePath);
-        $content = file_get_contents($filePath);
-        $fxnName = 'from' . ucfirst($ext);
-
-        if (method_exists(get_called_class(), $fxnName))
+        try
         {
-            $this->handleDependencies($ext);
-            $this->saveTrackerOptions($relFilePath, $options);
-            $this->addArrayToTracker(
-                $name,
-                $this->$fxnName($content),
-                $relFilePath,
-                (array_key_exists('namespace', $options)) ? $options['namespace'] : null
-            );
+            $namespace = (isset($options['namespace'])) ? $options['namespace'] : null;
+
+            $dataItem = new DataItem($filePath);
+            $dataItem->setNamespace($namespace);
+
+            $this->saveTrackerOptions($dataItem->getRelativeFilePath(), $options);
+            $this->addObjectToTracker($dataItem, $dataItem->getName(), $namespace);
+
+            return $dataItem->getName();
         }
-        else
+        catch (DependencyMissingException $e)
         {
-            $this->output->warning("There is no function to handle '$ext' file format.");
+            if ($e->getDependency() === 'XML')
+            {
+                $this->output->critical('XML support is not available in your PHP installation. For XML support, please install the appropriate package for your system:');
+                $this->output->critical('  e.g. php7.0-xml');
+            }
         }
-
-        return $name;
-    }
-
-    /**
-     * Convert from CSV into an associative array.
-     *
-     * @param string $content CSV formatted text
-     *
-     * @return array
-     */
-    private function fromCsv($content)
-    {
-        $rows = array_map('str_getcsv', explode("\n", trim($content)));
-        $columns = array_shift($rows);
-        $csv = array();
-
-        foreach ($rows as $row)
+        catch (UnsupportedDataTypeException $e)
         {
-            $csv[] = array_combine($columns, $row);
+            $this->output->warning(StrUtils::interpolate('There is no function to handle {ext} file format.', array(
+                'ext' => $e->getDataType()
+            )));
         }
 
-        return $csv;
-    }
-
-    /**
-     * Convert from JSON into an associative array.
-     *
-     * @param string $content JSON formatted text
-     *
-     * @return array
-     */
-    private function fromJson($content)
-    {
-        return json_decode($content, true);
-    }
-
-    /**
-     * Convert from XML into an associative array.
-     *
-     * @param string $content XML formatted text
-     *
-     * @return array
-     */
-    private function fromXml($content)
-    {
-        return json_decode(json_encode(simplexml_load_string($content)), true);
-    }
-
-    /**
-     * Convert from YAML into an associative array.
-     *
-     * @param string $content YAML formatted text
-     *
-     * @return array
-     */
-    private function fromYaml($content)
-    {
-        return Yaml::parse($content, Yaml::PARSE_DATETIME);
-    }
-
-    /**
-     * An alias for handling `*.yml` files.
-     *
-     * @param string $content YAML formatted text
-     *
-     * @return array
-     */
-    private function fromYml($content)
-    {
-        return $this->fromYaml($content);
-    }
-
-    /**
-     * @param string $extension
-     *
-     * @todo 0.1.0 Create a help page on the main stakx website for this topic and link to it
-     *
-     * @throws DependencyMissingException
-     */
-    private function handleDependencies($extension)
-    {
-        if ($extension === 'xml' && !function_exists('simplexml_load_string'))
-        {
-            $this->output->critical('XML support is not available in your PHP installation. For XML support, please install the appropriate package for your system:');
-            $this->output->critical('  e.g. php7.0-xml');
-
-            throw new DependencyMissingException('XML support is not available with the current PHP installation.');
-        }
+        return $this->fs->getBaseName($filePath);
     }
 }

--- a/src/allejo/stakx/Manager/PageManager.php
+++ b/src/allejo/stakx/Manager/PageManager.php
@@ -8,10 +8,12 @@
 namespace allejo\stakx\Manager;
 
 use allejo\stakx\Document\ContentItem;
+use allejo\stakx\Document\DataItem;
 use allejo\stakx\Document\DynamicPageView;
 use allejo\stakx\Document\JailedDocument;
 use allejo\stakx\Document\PageView;
 use allejo\stakx\Exception\CollectionNotFoundException;
+use allejo\stakx\Exception\DataSetNotFoundException;
 use allejo\stakx\System\FileExplorer;
 
 /**
@@ -39,6 +41,11 @@ class PageManager extends TrackingManager
     private $staticPages;
 
     /**
+     * @var DataItem[]|array
+     */
+    private $datasets;
+
+    /**
      * PageManager constructor.
      */
     public function __construct()
@@ -64,6 +71,11 @@ class PageManager extends TrackingManager
     public function setCollections(&$collections)
     {
         $this->collections = &$collections;
+    }
+
+    public function setDatasets(&$datasets)
+    {
+        $this->datasets = &$datasets;
     }
 
     /**
@@ -237,14 +249,17 @@ class PageManager extends TrackingManager
     private function handleTrackableDynamicPageView(&$pageView)
     {
         $frontMatter = $pageView->getFrontMatter(false);
-        $collection = $frontMatter['collection'];
+        $namespace = (isset($frontMatter['collection'])) ? 'collection' : 'dataset';
 
-        if (!isset($this->collections[$collection]))
+        $collection = $frontMatter[$namespace];
+        $array = $namespace . 's';
+
+        if (!isset($this->{$array}[$collection]))
         {
-            throw new CollectionNotFoundException("The '$collection' collection is not defined");
+            throw new CollectionNotFoundException("The '$collection' $namespace is not defined");
         }
 
-        foreach ($this->collections[$collection] as &$item)
+        foreach ($this->{$array}[$collection] as &$item)
         {
             $item->evaluateFrontMatter($frontMatter);
             $pageView->addRepeatableItem($item);

--- a/src/allejo/stakx/Manager/PageManager.php
+++ b/src/allejo/stakx/Manager/PageManager.php
@@ -177,8 +177,8 @@ class PageManager extends TrackingManager
      */
     public function trackNewContentItem(&$contentItem)
     {
-        $collection = $contentItem->getCollection();
-        $this->trackedItems[PageView::DYNAMIC_TYPE][$collection]->addContentItem($contentItem);
+        $collection = $contentItem->getNamespace();
+        $this->trackedItems[PageView::DYNAMIC_TYPE][$collection]->addRepeatableItem($contentItem);
     }
 
     /**
@@ -198,7 +198,7 @@ class PageManager extends TrackingManager
 
             case PageView::DYNAMIC_TYPE:
                 $this->handleTrackableDynamicPageView($pageView);
-                $storageKey = $pageView->getCollection();
+                $storageKey = $pageView->getRepeatableName();
                 break;
 
             default:
@@ -247,7 +247,7 @@ class PageManager extends TrackingManager
         foreach ($this->collections[$collection] as &$item)
         {
             $item->evaluateFrontMatter($frontMatter);
-            $pageView->addContentItem($item);
+            $pageView->addRepeatableItem($item);
         }
     }
 }

--- a/src/allejo/stakx/Manager/PageManager.php
+++ b/src/allejo/stakx/Manager/PageManager.php
@@ -73,9 +73,9 @@ class PageManager extends TrackingManager
         $this->collections = &$collections;
     }
 
-    public function setDatasets(&$datasets)
+    public function setDatasets($datasets)
     {
-        $this->datasets = &$datasets;
+        $this->datasets = $datasets;
     }
 
     /**

--- a/src/allejo/stakx/Manager/TrackingManager.php
+++ b/src/allejo/stakx/Manager/TrackingManager.php
@@ -7,7 +7,8 @@
 
 namespace allejo\stakx\Manager;
 
-use allejo\stakx\FrontMatter\Document;
+use allejo\stakx\Document\TwigDocumentInterface;
+use allejo\stakx\FrontMatter\FrontMatterDocument;
 use allejo\stakx\System\FileExplorer;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -181,15 +182,15 @@ abstract class TrackingManager extends BaseManager
     /**
      * Add a FrontMatterObject based object to the tracker.
      *
-     * @param Document    $trackedItem
-     * @param string      $key
+     * @param TwigDocumentInterface $trackedItem
+     * @param string $key
      * @param string|null $namespace
      */
     protected function addObjectToTracker($trackedItem, $key, $namespace = null)
     {
-        if (!($trackedItem instanceof Document))
+        if (!($trackedItem instanceof FrontMatterDocument) && !($trackedItem instanceof TwigDocumentInterface))
         {
-            throw new \InvalidArgumentException('Only objects can be added to the tracker');
+            throw new \InvalidArgumentException('Only TwigDocumentInterface objects can be added to the tracker');
         }
 
         $this->addArrayToTracker($key, $trackedItem, $trackedItem->getRelativeFilePath(), $namespace);

--- a/src/allejo/stakx/Manager/TrackingManager.php
+++ b/src/allejo/stakx/Manager/TrackingManager.php
@@ -7,8 +7,11 @@
 
 namespace allejo\stakx\Manager;
 
+use allejo\stakx\Command\BuildableCommand;
+use allejo\stakx\Document\JailedDocument;
 use allejo\stakx\Document\TwigDocumentInterface;
 use allejo\stakx\FrontMatter\FrontMatterDocument;
+use allejo\stakx\Service;
 use allejo\stakx\System\FileExplorer;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -273,6 +276,29 @@ abstract class TrackingManager extends BaseManager
         {
             $this->handleTrackableItem($file, $options);
         }
+    }
+
+    /**
+     * Return an array of JailedDocuments created from the tracked items
+     *
+     * @return JailedDocument[]
+     */
+    protected function getJailedTrackedItems()
+    {
+        $jailItems = array();
+
+        /**
+         * @var string $key
+         * @var TwigDocumentInterface $item
+         */
+        foreach ($this->trackedItemsFlattened as &$item)
+        {
+            if (!Service::getParameter(BuildableCommand::USE_DRAFTS) && $item->isDraft()) { continue; }
+
+            $jailItems[$item->getNamespace()][$item->getName()] = $item->createJail();
+        }
+
+        return $jailItems;
     }
 
     /**

--- a/src/allejo/stakx/Twig/WhereFilter.php
+++ b/src/allejo/stakx/Twig/WhereFilter.php
@@ -8,7 +8,7 @@
 namespace allejo\stakx\Twig;
 
 use allejo\stakx\Document\JailedDocument;
-use allejo\stakx\FrontMatter\Document;
+use allejo\stakx\FrontMatter\FrontMatterDocument;
 use Twig_Error_Syntax;
 
 /**
@@ -132,7 +132,7 @@ class WhereFilter
             return false;
         }
 
-        if ($array->coreInstanceOf(Document::class) && !isset($array[$key]))
+        if ($array->coreInstanceOf(FrontMatterDocument::class) && !isset($array[$key]))
         {
             if ($comparison == '==' && is_null($value))
             {

--- a/src/allejo/stakx/Website.php
+++ b/src/allejo/stakx/Website.php
@@ -347,7 +347,7 @@ class Website
             $this->compiler->compileContentItem($contentItem);
             $this->compiler->compileSome(array(
                 'namespace'  => 'collections',
-                'dependency' => $contentItem->getCollection(),
+                'dependency' => $contentItem->getNamespace(),
             ));
         }
         elseif ($this->dm->isHandled($filePath))
@@ -394,7 +394,7 @@ class Website
             $this->compiler->compileContentItem($contentItem);
             $this->compiler->compileSome(array(
                 'namespace'  => 'collections',
-                'dependency' => $contentItem->getCollection(),
+                'dependency' => $contentItem->getNamespace(),
             ));
         }
         elseif ($this->dm->isTracked($filePath))

--- a/src/allejo/stakx/Website.php
+++ b/src/allejo/stakx/Website.php
@@ -137,6 +137,7 @@ class Website
         $this->pm->setLogger($this->output);
         $this->pm->enableTracking($tracking);
         $this->pm->setCollections($this->cm->getCollections());
+        $this->pm->setDatasets($this->dm->getDataItems());
         $this->pm->parsePageViews($this->getConfiguration()->getPageViewFolders());
 
         // Handle the site's menu

--- a/src/allejo/stakx/Website.php
+++ b/src/allejo/stakx/Website.php
@@ -154,7 +154,7 @@ class Website
                 array('name' => 'collections', 'value' => $this->cm->getJailedCollections()),
                 array('name' => 'menu', 'value' => $this->mm->getSiteMenu()),
                 array('name' => 'pages', 'value' => $this->pm->getJailedStaticPageViews()),
-                array('name' => 'data', 'value' => $this->dm->getDataItems()),
+                array('name' => 'data', 'value' => $this->dm->getJailedDataItems()),
             ),
         ));
 

--- a/tests/allejo/stakx/Test/CompilerTest.php
+++ b/tests/allejo/stakx/Test/CompilerTest.php
@@ -237,7 +237,7 @@ class CompilerTest extends PHPUnit_Stakx_TestCase
         foreach ($books['books'] as &$item)
         {
             $item->evaluateFrontMatter($pageView->getFrontMatter(false));
-            $pageView->addContentItem($item);
+            $pageView->addRepeatableItem($item);
         }
 
         $this->compiler->setPageViews($pageViews, $pageViewsFlattened);

--- a/tests/allejo/stakx/Test/ConfigurationTest.php
+++ b/tests/allejo/stakx/Test/ConfigurationTest.php
@@ -140,7 +140,7 @@ class ConfigurationTest extends PHPUnit_Stakx_TestCase
     public function testInvalidConfigurationFails()
     {
         $output = $this->getReadableLogger();
-        $configPath = $this->writeTempFile('_config.yml', "foo: bar\nfoo baz");
+        $configPath = $this->createTempFile('_config.yml', "foo: bar\nfoo baz");
 
         $config = new Configuration();
         $config->setLogger($output);
@@ -272,7 +272,7 @@ value_one: 1
 
         foreach ($rules['files'] as $fileName => $fileContent)
         {
-            $files[] = $this->writeTempFile($fileName, $fileContent);
+            $files[] = $this->createTempFile($fileName, $fileContent);
         }
 
         $masterConfig = $files[0];
@@ -292,8 +292,8 @@ value_one: 1
 
     public function testConfigurationImportDirectoryFails()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - hello/");
-        $this->writeTempFile('hello/world.yml', 'dummy file');
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - hello/");
+        $this->createTempFile('hello/world.yml', 'dummy file');
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -304,7 +304,7 @@ value_one: 1
 
     public function testConfigurationImportSelfFails()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - _config.yml");
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - _config.yml");
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -315,8 +315,8 @@ value_one: 1
 
     public function testConfigurationImportNonYamlFails()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - my_xml.xml");
-        $this->writeTempFile('my_xml.xml', '<root></root>');
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - my_xml.xml");
+        $this->createTempFile('my_xml.xml', '<root></root>');
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -327,8 +327,8 @@ value_one: 1
 
     public function testConfigurationImportSymlinkFails()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - my_sym.yml");
-        $this->writeTempFile('original_file.yml', 'value: one');
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - my_sym.yml");
+        $this->createTempFile('original_file.yml', 'value: one');
         $this->fs->symlink(
             $this->fs->appendPath($this->assetFolder, 'original_file.yml'),
             $this->fs->appendPath($this->assetFolder, 'my_sym.yml')
@@ -343,7 +343,7 @@ value_one: 1
 
     public function testConfigurationImportFileNotFound()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - fake_file.yml");
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - fake_file.yml");
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -354,9 +354,9 @@ value_one: 1
 
     public function testConfigurationImportGrandchild()
     {
-        $masterConfig = $this->writeTempFile('grandparent.yml', "import:\n  - parent.yml\ngrandparent_value: 1");
-        $this->writeTempFile('parent.yml', "import:\n  - child.yml\nparent_value: 2");
-        $this->writeTempFile('child.yml', 'child_value: 3');
+        $masterConfig = $this->createTempFile('grandparent.yml', "import:\n  - parent.yml\ngrandparent_value: 1");
+        $this->createTempFile('parent.yml', "import:\n  - child.yml\nparent_value: 2");
+        $this->createTempFile('child.yml', 'child_value: 3');
 
         $config = new Configuration();
         $config->setLogger($this->getMockLogger());
@@ -370,8 +370,8 @@ value_one: 1
 
     public function testConfigurationImportRecursivelyFails()
     {
-        $masterConfig = $this->writeTempFile('_config.yml', "import:\n  - _second.yml");
-        $this->writeTempFile('_second.yml', "import:\n  - _config.yml");
+        $masterConfig = $this->createTempFile('_config.yml', "import:\n  - _second.yml");
+        $this->createTempFile('_second.yml', "import:\n  - _config.yml");
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -396,7 +396,7 @@ value_one: 1
      */
     public function testConfigurationInvalidImportArrayFails($invalidImportArray)
     {
-        $configPath = $this->writeTempFile('config.yml', $invalidImportArray);
+        $configPath = $this->createTempFile('config.yml', $invalidImportArray);
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -422,7 +422,7 @@ value_one: 1
      */
     public function testConfigurationImportNotAnArray($invalidImport)
     {
-        $configPath = $this->writeTempFile('config.yml', $invalidImport);
+        $configPath = $this->createTempFile('config.yml', $invalidImport);
 
         $config = new Configuration();
         $config->setLogger($this->getReadableLogger());
@@ -433,7 +433,7 @@ value_one: 1
 
     public function testDeprecatedBase()
     {
-        $configPath = $this->writeTempFile('_config.yml', 'base: /my-deprecated');
+        $configPath = $this->createTempFile('_config.yml', 'base: /my-deprecated');
 
         $config = new Configuration();
         $config->setLogger($this->getMockLogger());
@@ -444,7 +444,7 @@ value_one: 1
 
     public function testDeprecatedBasePriority()
     {
-        $configPath = $this->writeTempFile('_config.yml', "base: /my-deprecated\nbaseurl: /my-new");
+        $configPath = $this->createTempFile('_config.yml', "base: /my-deprecated\nbaseurl: /my-new");
 
         $config = new Configuration();
         $config->setLogger($this->getMockLogger());

--- a/tests/allejo/stakx/Test/Document/ContentItemTest.php
+++ b/tests/allejo/stakx/Test/Document/ContentItemTest.php
@@ -12,7 +12,7 @@ use allejo\stakx\Engines\Markdown\MarkdownEngine;
 use allejo\stakx\Engines\RST\RstEngine;
 use allejo\stakx\Exception\FileAwareException;
 use allejo\stakx\Exception\InvalidSyntaxException;
-use allejo\stakx\FrontMatter\Document;
+use allejo\stakx\FrontMatter\FrontMatterDocument;
 use allejo\stakx\FrontMatter\Exception\YamlVariableUndefinedException;
 use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
 use org\bovigo\vfs\vfsStream;
@@ -45,7 +45,7 @@ class ContentItemTests extends PHPUnit_Stakx_TestCase
         $item = $this->createContentItemWithEmptyFrontMatter();
 
         // The only defined keys should be the ones specially defined
-        $this->assertCount(count(Document::$specialFrontMatterKeys), $item->getFrontMatter());
+        $this->assertCount(count(FrontMatterDocument::$specialFrontMatterKeys), $item->getFrontMatter());
     }
 
     public function testContentItemWithValidFrontMatter()

--- a/tests/allejo/stakx/Test/Document/DataItemTest.php
+++ b/tests/allejo/stakx/Test/Document/DataItemTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Test\Document;
+
+use allejo\stakx\Document\DataItem;
+use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
+
+class DataItemTest extends PHPUnit_Stakx_TestCase
+{
+    public function testJsonAsDataItem()
+    {
+        $jsonFile = <<<LINE
+{
+  "array": [
+    1,
+    2,
+    3
+  ],
+  "boolean": true,
+  "null": null,
+  "number": 123,
+  "object": {
+    "a": "b",
+    "c": "d",
+    "e": "f"
+  },
+  "string": "Hello World"
+}
+LINE;
+        /** @var DataItem $dataItem */
+        $dataItem = $this->createBlankFile('my-sample-JSON.json', DataItem::class, $jsonFile);
+
+        $this->assertEquals('my-sample-JSON', $dataItem->getName());
+        $this->assertEquals(array(1, 2, 3), $dataItem['array']);
+        $this->assertTrue($dataItem['boolean']);
+        $this->assertNull($dataItem['null']);
+        $this->assertEquals(123, $dataItem['number']);
+        $this->assertEquals('Hello World', $dataItem['string']);
+
+        $this->assertEquals(array(
+            'array' => array(1, 2, 3),
+            'boolean' => true,
+            'null' => null,
+            'number' => 123,
+            'object' => array(
+                'a' => 'b',
+                'c' => 'd',
+                'e' => 'f',
+            ),
+            'string' => 'Hello World',
+        ), $dataItem->getData());
+    }
+
+    public function testCsvAsDataItem()
+    {
+        $csvFile = <<<LINE
+id,name,gender
+1,John Doe,M
+2,Jane Doe,F
+LINE;
+        /** @var DataItem $dataItem */
+        $dataItem = $this->createBlankFile('my-file.csv', DataItem::class, $csvFile);
+        $jailItem = $dataItem->createJail();
+
+        $this->assertEquals($dataItem[0], $jailItem[0]);
+        $this->assertEquals($dataItem->getIterator(), $jailItem->getIterator());
+        $this->assertEquals('my-file', $jailItem->getName());
+        $this->assertEquals('csv', $jailItem->getExtension());
+
+        $this->assertEquals(array(
+            array(
+                'id' => 1,
+                'name' => 'John Doe',
+                'gender' => 'M',
+            ),
+            array(
+                'id' => 2,
+                'name' => 'Jane Doe',
+                'gender' => 'F',
+            ),
+        ), $dataItem->getData());
+    }
+}

--- a/tests/allejo/stakx/Test/Document/DataItemTest.php
+++ b/tests/allejo/stakx/Test/Document/DataItemTest.php
@@ -37,6 +37,7 @@ class DataItemTest extends PHPUnit_Stakx_TestCase
 LINE;
         /** @var DataItem $dataItem */
         $dataItem = $this->createBlankFile('my-sample-JSON.json', DataItem::class, $jsonFile);
+        $jailItem = $dataItem->createJail();
 
         $this->assertEquals('my-sample-JSON', $dataItem->getName());
         $this->assertEquals(array(1, 2, 3), $dataItem['array']);
@@ -44,6 +45,11 @@ LINE;
         $this->assertNull($dataItem['null']);
         $this->assertEquals(123, $dataItem['number']);
         $this->assertEquals('Hello World', $dataItem['string']);
+
+        foreach (array('array', 'boolean', 'null', 'number', 'string') as $key)
+        {
+            $this->assertEquals($dataItem[$key], $jailItem[$key]);
+        }
 
         $this->assertEquals(array(
             'array' => array(1, 2, 3),
@@ -73,7 +79,9 @@ LINE;
         $this->assertEquals($dataItem[0], $jailItem[0]);
         $this->assertEquals($dataItem->getIterator(), $jailItem->getIterator());
         $this->assertEquals('my-file', $jailItem->getName());
+        $this->assertEquals($dataItem->getName(), $jailItem->getName());
         $this->assertEquals('csv', $jailItem->getExtension());
+        $this->assertEquals($dataItem->getExtension(), $jailItem->getExtension());
 
         $this->assertEquals(array(
             array(

--- a/tests/allejo/stakx/Test/Manager/CollectionManagerTest.php
+++ b/tests/allejo/stakx/Test/Manager/CollectionManagerTest.php
@@ -66,7 +66,7 @@ class CollectionManagerTests extends PHPUnit_Stakx_TestCase
         );
 
         $this->assertNotNull($contentItem);
-        $this->assertEquals('My Books', $contentItem->getCollection());
+        $this->assertEquals('My Books', $contentItem->getNamespace());
         $this->assertEquals('0763680877', $contentItem['isbn_10']);
     }
 

--- a/tests/allejo/stakx/Test/Manager/DataManagerTest.php
+++ b/tests/allejo/stakx/Test/Manager/DataManagerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright 2017 Vladimir Jimenez
+ * @license   https://github.com/allejo/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Test\Manager;
+
+use allejo\stakx\Document\DataItem;
+use allejo\stakx\Manager\DataManager;
+use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
+
+class DataManagerTest extends PHPUnit_Stakx_TestCase
+{
+    public function testDataSetParsing()
+    {
+        $dataSetName = 'calendar';
+
+        $dm = new DataManager();
+        $dm->parseDataSets(array(array(
+            'name' => $dataSetName,
+            'folder' => $this->fs->appendPath(__DIR__, '../assets/MyDataSet'),
+        )));
+
+        $this->assertGreaterThan(0, $dm->getDataItems());
+        $this->assertGreaterThan(0, $dm->getJailedDataItems());
+
+        /**
+         * @var string $key
+         * @var DataItem[] $items
+         */
+        foreach ($dm->getDataItems() as $key => $items)
+        {
+            $this->assertEquals($key, $dataSetName);
+
+            foreach ($items as $item)
+            {
+                $this->assertInstanceOf(DataItem::class, $item);
+                $this->assertEquals($dataSetName, $item->getNamespace());
+            }
+        }
+    }
+
+    public function testDataItemParsing()
+    {
+        $dm = new DataManager();
+        $dm->parseDataItems(array(
+            $this->fs->appendPath(__DIR__, '../assets/MyDataSet')
+        ));
+
+        $this->assertGreaterThan(0, $dm->getDataItems());
+        $this->assertGreaterThan(0, $dm->getJailedDataItems());
+
+        /** @var DataItem $item */
+        foreach ($dm->getDataItems() as $item)
+        {
+            $this->assertNull($item->getNamespace());
+        }
+    }
+}

--- a/tests/allejo/stakx/Test/Manager/PageManagerTest.php
+++ b/tests/allejo/stakx/Test/Manager/PageManagerTest.php
@@ -51,7 +51,7 @@ class PageManagerTest extends PHPUnit_Stakx_TestCase
 
         $pageViews = $pageManager->getAllPageViews();
         $pageView = current($pageViews);
-        $contentItems = $pageView->getContentItems();
+        $contentItems = $pageView->getRepeatableItems();
 
         $this->assertEquals($collections['books'], $contentItems);
     }
@@ -132,16 +132,16 @@ class PageManagerTest extends PHPUnit_Stakx_TestCase
         /** @var DynamicPageView $pageView */
         $pageView = current($pageViews);
 
-        $originalCount = count($pageView->getContentItems());
+        $originalCount = count($pageView->getRepeatableItems());
         $this->assertGreaterThan(0, $originalCount);
 
         /** @var ContentItem $contentItem */
         $contentItem = $this->createVirtualFile(ContentItem::class);
-        $contentItem->setCollection('books');
+        $contentItem->setNamespace('books');
 
         $pageManager->trackNewContentItem($contentItem);
 
-        $this->assertCount($originalCount + 1, $pageView->getContentItems());
+        $this->assertCount($originalCount + 1, $pageView->getRepeatableItems());
     }
 
     public function testWarningThrownWhenPageViewFolderNotFound()

--- a/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
+++ b/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
@@ -91,6 +91,22 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Write a temporary file to the asset folder
+     *
+     * @param $fileName
+     * @param $content
+     *
+     * @return string Path to the temporary file; relative to the project's root
+     */
+    protected function createTempFile($fileName, $content)
+    {
+        $folder = new Folder($this->assetFolder);
+        $folder->writeFile($fileName, $content);
+
+        return $this->fs->appendPath($this->assetFolder, $fileName);
+    }
+
+    /**
      * @param string $classType
      * @param array  $frontMatter
      * @param string $body
@@ -177,21 +193,5 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         $this->assetFolder = $this->fs->getRelativePath($this->fs->appendPath(__DIR__, $folderName));
 
         $this->fs->mkdir($this->assetFolder);
-    }
-
-    /**
-     * Write a temporary file to the asset folder
-     *
-     * @param $fileName
-     * @param $content
-     *
-     * @return string Path to the temporary file; relative to the project's root
-     */
-    protected function writeTempFile($fileName, $content)
-    {
-        $folder = new Folder($this->assetFolder);
-        $folder->writeFile($fileName, $content);
-
-        return $this->fs->appendPath($this->assetFolder, $fileName);
     }
 }

--- a/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
+++ b/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
@@ -48,6 +48,7 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         $this->rootDir = vfsStream::setup();
         $this->fs = new Filesystem();
 
+        Service::setParameter(BuildableCommand::USE_DRAFTS, false);
         Service::setParameter(BuildableCommand::WATCHING, false);
 
         // Inspect the VFS as an array

--- a/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
+++ b/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
@@ -106,6 +106,16 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         return $this->fs->appendPath($this->assetFolder, $fileName);
     }
 
+    protected function createBlankFile($filename, $classType, $content)
+    {
+        $file = vfsStream::newFile($filename);
+        $file
+            ->setContent($content)
+            ->at($this->rootDir);
+
+        return new $classType($file->url());
+    }
+
     /**
      * @param string $classType
      * @param array  $frontMatter

--- a/tests/allejo/stakx/Test/Twig/WhereFilterTest.php
+++ b/tests/allejo/stakx/Test/Twig/WhereFilterTest.php
@@ -7,7 +7,9 @@
 
 namespace allejo\stakx\Test\Twig;
 
+use allejo\stakx\Command\BuildableCommand;
 use allejo\stakx\Document\ContentItem;
+use allejo\stakx\Service;
 use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
 use allejo\stakx\Twig\WhereFilter;
 
@@ -18,6 +20,8 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
     public function setUp()
     {
         parent::setUp();
+
+        Service::setParameter(BuildableCommand::USE_DRAFTS, true);
 
         $this->dataset = array(
             array(

--- a/tests/allejo/stakx/Test/assets/MyDataSet/december.yml
+++ b/tests/allejo/stakx/Test/assets/MyDataSet/december.yml
@@ -1,0 +1,4 @@
+month: December
+events:
+  - date: 2016-12-25 00:00:00.00 -8
+    name: Christmas Day

--- a/tests/allejo/stakx/Test/assets/MyDataSet/january.yml
+++ b/tests/allejo/stakx/Test/assets/MyDataSet/january.yml
@@ -1,0 +1,6 @@
+month: January
+events:
+  - date: 2016-01-01 00:00:00.00 -8
+    name: New Year's Day
+  - date: 2016-01-18 00:00:00.00 -8
+    name: Birthday of Martin Luther King, Jr.


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | #47 

### Description

Add the ability to iterator through datasets the same way a dynamic PageView can iterator through a collection

### To do

- [x] Jail the DataItem objects
- [x] Actually make the `dataset` FM key work

### Check List

- [x] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
