### PR TITLE
Support dot notation in Twig filters

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -145,12 +145,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/maciejczyzewski/bottomline.git",
-                "reference": "1d1fa0d851f39310ccb2df55256aa4b7585adbcd"
+                "reference": "f24b923afccec02be496130848996d6144af87a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/1d1fa0d851f39310ccb2df55256aa4b7585adbcd",
-                "reference": "1d1fa0d851f39310ccb2df55256aa4b7585adbcd",
+                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/f24b923afccec02be496130848996d6144af87a8",
+                "reference": "f24b923afccec02be496130848996d6144af87a8",
                 "shasum": ""
             },
             "require": {
@@ -187,7 +187,7 @@
                 "library",
                 "utility"
             ],
-            "time": "2018-02-10 09:58:57"
+            "time": "2018-04-10 21:47:58"
         },
         {
             "name": "mikey179/vfsStream",

--- a/composer.lock
+++ b/composer.lock
@@ -145,12 +145,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/maciejczyzewski/bottomline.git",
-                "reference": "f24b923afccec02be496130848996d6144af87a8"
+                "reference": "87c42c030944a2aa04b8e02794fe5d600a0346b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/f24b923afccec02be496130848996d6144af87a8",
-                "reference": "f24b923afccec02be496130848996d6144af87a8",
+                "url": "https://api.github.com/repos/maciejczyzewski/bottomline/zipball/87c42c030944a2aa04b8e02794fe5d600a0346b9",
+                "reference": "87c42c030944a2aa04b8e02794fe5d600a0346b9",
                 "shasum": ""
             },
             "require": {
@@ -187,7 +187,7 @@
                 "library",
                 "utility"
             ],
-            "time": "2018-04-10 21:47:58"
+            "time": "2018-05-22 03:36:35"
         },
         {
             "name": "mikey179/vfsStream",

--- a/src/allejo/stakx/Templating/Twig/Extension/GroupByFilter.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/GroupByFilter.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\Templating\Twig\Extension;
 
+use __;
+
 class GroupByFilter extends AbstractTwigExtension implements TwigFilterInterface
 {
     public function __invoke($array, $sortKey)
@@ -15,12 +17,12 @@ class GroupByFilter extends AbstractTwigExtension implements TwigFilterInterface
 
         foreach ($array as $key => $item)
         {
-            if (!isset($item[$sortKey]))
+            $groupBy = __::get($item, $sortKey);
+
+            if ($groupBy === null)
             {
                 continue;
             }
-
-            $groupBy = $item[$sortKey];
 
             if (is_bool($groupBy))
             {

--- a/src/allejo/stakx/Templating/Twig/Extension/OrderFilter.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/OrderFilter.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\Templating\Twig\Extension;
 
+use __;
+
 class OrderFilter extends AbstractTwigExtension implements TwigFilterInterface
 {
     public function __invoke($array, $key, $order = 'ASC')
@@ -17,17 +19,20 @@ class OrderFilter extends AbstractTwigExtension implements TwigFilterInterface
         }
 
         usort($array, function ($a, $b) use ($key, $order) {
-            if ($a[$key] == $b[$key])
+            $aValue = __::get($a, $key);
+            $bValue = __::get($b, $key);
+
+            if ($aValue == $bValue)
             {
                 return 0;
             }
 
             if (strtolower($order) === 'desc')
             {
-                return ($a[$key] < $b[$key]) ? 1 : -1;
+                return ($aValue < $bValue) ? 1 : -1;
             }
 
-            return ($a[$key] > $b[$key]) ? 1 : -1;
+            return ($aValue > $bValue) ? 1 : -1;
         });
 
         return $array;

--- a/src/allejo/stakx/Templating/Twig/Extension/SelectFilter.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/SelectFilter.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\Templating\Twig\Extension;
 
+use __;
+
 class SelectFilter extends AbstractTwigExtension implements TwigFilterInterface
 {
     public function __invoke($array, $key, $flatten = true, $distinct = true, $ignore_null = true)
@@ -15,42 +17,22 @@ class SelectFilter extends AbstractTwigExtension implements TwigFilterInterface
 
         foreach ($array as $item)
         {
-            if (!is_array($item) && !($item instanceof \ArrayAccess))
-            {
-                continue;
-            }
-
-            if ($ignore_null)
-            {
-                if (isset($item[$key]))
-                {
-                    $results[] = $item[$key];
-                }
-            }
-            else
-            {
-                if (array_key_exists($key, $item) || ($item instanceof \ArrayAccess && $item->offsetExists($key)))
-                {
-                    $results[] = $item[$key];
-                }
-            }
+            $results[] = __::get($item, $key);
         }
 
         if ($flatten)
         {
-            $results = self::flatten($results);
+            $results = __::flatten($results);
 
             if ($distinct)
             {
-                $distinct = [];
-
-                foreach ($results as $key => $result)
-                {
-                    $distinct[$result] = true;
-                }
-
-                $results = array_keys($distinct);
+                $results = array_values(array_unique($results));
             }
+        }
+
+        if ($ignore_null)
+        {
+            $results = array_values(array_filter($results));
         }
 
         return $results;
@@ -59,15 +41,5 @@ class SelectFilter extends AbstractTwigExtension implements TwigFilterInterface
     public static function get()
     {
         return new \Twig_SimpleFilter('select', new self());
-    }
-
-    private static function flatten(array $array)
-    {
-        $return = [];
-        array_walk_recursive($array, function ($a) use (&$return) {
-            $return[] = $a;
-        });
-
-        return $return;
     }
 }

--- a/src/allejo/stakx/Templating/Twig/Extension/WhereFilter.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/WhereFilter.php
@@ -7,6 +7,7 @@
 
 namespace allejo\stakx\Templating\Twig\Extension;
 
+use __;
 use Twig_Error_Syntax;
 
 /**
@@ -95,17 +96,22 @@ class WhereFilter extends AbstractTwigExtension implements TwigFilterInterface
      */
     private function compare($array, $key, $comparison, $value)
     {
+        // @TODO can I replace the $array/$key separate parameters with `__::get()`?
+        // @TODO right now, a call to `__::get()` will return null, so that would break the null comparisons
+        // @TODO maybe use `__::has()`?
         if ($this->compareNullValues($array, $key, $comparison, $value))
         {
             return true;
         }
 
-        if (!isset($array[$key]))
+        $lhsValue = __::get($array, $key);
+
+        if ($lhsValue === null)
         {
             return false;
         }
 
-        return $this->comparisonSymbol($array[$key], $comparison, $value);
+        return $this->comparisonSymbol($lhsValue, $comparison, $value);
     }
 
     /**
@@ -130,13 +136,13 @@ class WhereFilter extends AbstractTwigExtension implements TwigFilterInterface
             return false;
         }
 
-        if (!isset($array[$key]))
+        if (!__::has($array, $key))
         {
-            if ($comparison == '==' && is_null($value))
+            if ($comparison == '==' && $value === null)
             {
                 return true;
             }
-            if ($comparison == '!=' && !is_null($value))
+            if ($comparison == '!=' && $value !== null)
             {
                 return true;
             }

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/GroupByFilterTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/GroupByFilterTest.php
@@ -47,6 +47,41 @@ class GroupByFilterTests extends PHPUnit_Stakx_TestCase
 
         $this->assertEquals($expected, $grouped);
     }
+    public function testGroupByFilterDotNotation()
+    {
+        $original = [
+            'a' => ['metadata' => ['id' => 20], 'name' => 'chimpanzee'],
+            'b' => ['metadata' => ['id' => 40], 'name' => 'meeting'],
+            'c' => ['metadata' => ['id' => 20], 'name' => 'dynasty'],
+            'd' => ['metadata' => ['id' => 50], 'name' => 'chocolate'],
+            'e' => ['metadata' => ['id' => 10], 'name' => 'bananas'],
+            'f' => ['metadata' => ['id' => 50], 'name' => 'fantasy'],
+            'g' => ['metadata' => ['id' => 50], 'name' => 'football'],
+        ];
+
+        $expected = [
+            '10' => [
+                'e' => ['metadata' => ['id' => 10], 'name' => 'bananas'],
+            ],
+            '20' => [
+                'a' => ['metadata' => ['id' => 20], 'name' => 'chimpanzee'],
+                'c' => ['metadata' => ['id' => 20], 'name' => 'dynasty'],
+            ],
+            '40' => [
+                'b' => ['metadata' => ['id' => 40], 'name' => 'meeting'],
+            ],
+            '50' => [
+                'd' => ['metadata' => ['id' => 50], 'name' => 'chocolate'],
+                'f' => ['metadata' => ['id' => 50], 'name' => 'fantasy'],
+                'g' => ['metadata' => ['id' => 50], 'name' => 'football'],
+            ],
+        ];
+
+        $gbFilter = new GroupByFilter();
+        $grouped = $gbFilter($original, 'metadata.id');
+
+        $this->assertEquals($expected, $grouped);
+    }
 
     public function testGroupByFilterContentItems()
     {

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/OrderFilterTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/OrderFilterTest.php
@@ -10,9 +10,9 @@ namespace allejo\stakx\Test\Templating\Twig\Extension;
 use allejo\stakx\Templating\Twig\Extension\OrderFilter;
 use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
 
-class OrderByFilterTest extends PHPUnit_Stakx_TestCase
+class OrderFilterTest extends PHPUnit_Stakx_TestCase
 {
-    public static function dataProvider()
+    public static function dataProvider_singleLevelArray()
     {
         return [
             [
@@ -35,7 +35,7 @@ class OrderByFilterTest extends PHPUnit_Stakx_TestCase
     }
 
     /**
-     * @dataProvider dataProvider
+     * @dataProvider dataProvider_singleLevelArray
      *
      * @param array $dataset
      */
@@ -62,7 +62,7 @@ class OrderByFilterTest extends PHPUnit_Stakx_TestCase
     }
 
     /**
-     * @dataProvider dataProvider
+     * @dataProvider dataProvider_singleLevelArray
      *
      * @param array $dataset
      */
@@ -82,6 +82,101 @@ class OrderByFilterTest extends PHPUnit_Stakx_TestCase
             [
                 'name' => 'Whee',
                 'sort' => 0,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public static function dataProvider_multiLevelArray()
+    {
+        return [
+            [
+                [
+                    [
+                        'name' => 'Order of Bacon',
+                        'metadata' => [
+                            'sort' => 30,
+                        ],
+                    ],
+                    [
+                        'name' => 'Whee',
+                        'metadata' => [
+                            'sort' => 0,
+                        ],
+                    ],
+                    [
+                        'name' => 'Side order of fries',
+                        'metadata' => [
+                            'sort' => 3,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider_multiLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterAscNestedArray($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'metadata.sort');
+        $expected = [
+            [
+                'name' => 'Whee',
+                'metadata' => [
+                    'sort' => 0,
+                ],
+            ],
+            [
+                'name' => 'Side order of fries',
+                'metadata' => [
+                    'sort' => 3,
+                ],
+            ],
+            [
+                'name' => 'Order of Bacon',
+                'metadata' => [
+                    'sort' => 30,
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider dataProvider_multiLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterDescNestedArray($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'metadata.sort', 'DESC');
+        $expected =
+        $expected = [
+            [
+                'name' => 'Order of Bacon',
+                'metadata' => [
+                    'sort' => 30,
+                ],
+            ],
+            [
+                'name' => 'Side order of fries',
+                'metadata' => [
+                    'sort' => 3,
+                ],
+            ],
+            [
+                'name' => 'Whee',
+                'metadata' => [
+                    'sort' => 0,
+                ],
             ],
         ];
 

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/SelectFilterTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/SelectFilterTest.php
@@ -124,4 +124,18 @@ class SelectFilterTest extends PHPUnit_Stakx_TestCase
 
         $this->assertEquals(['hello', 'beautiful', null, 'world'], $results);
     }
+
+    public function testSelectFilterDotNotation()
+    {
+        $nestedArray = [
+            ['metadata' => ['tags' => ['php', 'programming']]],
+            ['metadata' => ['tags' => ['cooking']]],
+            ['metadata' => ''],
+            [],
+        ];
+        $filter = new SelectFilter();
+        $results = $filter($nestedArray, 'metadata.tags');
+
+        $this->assertEquals(['php', 'programming', 'cooking'], $results);
+    }
 }

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/WhereFilterTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/WhereFilterTest.php
@@ -7,6 +7,7 @@
 
 namespace allejo\stakx\Test\Templating\Twig\Extension;
 
+use __;
 use allejo\stakx\Command\BuildableCommand;
 use allejo\stakx\Document\ContentItem;
 use allejo\stakx\Service;
@@ -29,6 +30,10 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
                 'slug' => 'chimpanzee',
                 'cost' => 20,
                 'tags' => ['fun', 'monkey', 'banana'],
+                'author' => [
+                    'fname' => 'John',
+                    'lname' => 'Doe',
+                ],
             ],
             [
                 'name' => 'Two One',
@@ -41,24 +46,40 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
                 'slug' => 'dynasty',
                 'cost' => 20,
                 'tags' => ['monkey', 'animal', 'zoo'],
+                'author' => [
+                    'fname' => 'Joseph',
+                    'lname' => 'Alan',
+                ],
             ],
             [
                 'name' => 'Four One',
                 'slug' => 'chocolate',
                 'cost' => 50,
                 'tags' => ['fruit', 'port', 'computer'],
+                'author' => [
+                    'fname' => 'John',
+                    'lname' => 'Doe',
+                ],
             ],
             [
                 'name' => 'Five Five',
                 'slug' => 'bananas',
                 'cost' => 10,
                 'tags' => ['vegetable', 'purple', 'red', 'Bacon'],
+                'author' => [
+                    'fname' => 'Jane',
+                    'lname' => 'Doe',
+                ],
             ],
             [
                 'name' => 'Six Three',
                 'slug' => 'fantasy',
                 'cost' => 50,
                 'tags' => ['fruit', 'orange', 'purple'],
+                'author' => [
+                    'fname' => 'John',
+                    'lname' => 'Doe',
+                ],
             ],
         ];
     }
@@ -69,6 +90,8 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
             ['assertEquals', 'cost', '==', 50],
             ['assertEquals', 'cost', '==', 20],
             ['assertEquals', 'slug', '==', 'meeting'],
+            ['assertEquals', 'author.fname', '==', 'John'],
+            ['assertEquals', 'author.lname', '==', 'Doe'],
 
             // Weakly typed comparisons should fail
             ['assertNotEquals', 'cost', '==', '50'],
@@ -104,7 +127,7 @@ class WhereFilterTests extends PHPUnit_Stakx_TestCase
 
         foreach ($filtered as $item)
         {
-            $this->$fxn($value, $item[$key]);
+            $this->$fxn($value, __::get($item, $key));
         }
     }
 


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Closes #58

### Description

Add support for dot notation for multidimensional FrontMatter data to our Twig filters.

- [x] select
- [x] group
- [x] order
- [x] where

This PR also bumps bottomline to the latest master, which adds support for `ArrayAccess` objects.

### Blocked by

- ~~https://github.com/maciejczyzewski/bottomline/pull/42~~ ✅
- ~~https://github.com/maciejczyzewski/bottomline/pull/43~~ ✅

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
