### PR TITLE
Add support to `url()` Twig function to link to Repeater PageViews

### DIFF
--- a/example/_pages/blog/categories.html.twig
+++ b/example/_pages/blog/categories.html.twig
@@ -1,4 +1,5 @@
 ---
+title: Blog Categories
 permalink: /blog/categories/%{site.categories}/
 ---
 

--- a/example/_pages/blog/show.html.twig
+++ b/example/_pages/blog/show.html.twig
@@ -12,5 +12,12 @@ permalink: /blog/%year/%month/%day/%title/
         <section>
             {{ this.content }}
         </section>
+
+        <footer>
+            <span><i class="fa fa-tag"></i></span>
+            <a href="{{ url(repeaters['Blog Categories'], params = {
+                'site.categories': this.category
+            }) }}">{{ this.category | title }}</a>
+        </footer>
     </article>
 {% endblock %}

--- a/src/allejo/stakx/Compiler.php
+++ b/src/allejo/stakx/Compiler.php
@@ -65,6 +65,7 @@ class Compiler
     private $pageManager;
     private $eventDispatcher;
     private $configuration;
+    private $logger;
 
     public function __construct(
         TemplateBridgeInterface $templateBridge,
@@ -92,6 +93,7 @@ class Compiler
         $this->templateBridge->setGlobalVariable('collections', $collectionManager->getJailedCollections());
         $this->templateBridge->setGlobalVariable('menu', $menuManager->getSiteMenu());
         $this->templateBridge->setGlobalVariable('pages', $pageManager->getJailedStaticPageViews());
+        $this->templateBridge->setGlobalVariable('repeaters', $pageManager->getJailedRepeaterPageViews());
     }
 
     /**

--- a/src/allejo/stakx/Document/JailedDocument.php
+++ b/src/allejo/stakx/Document/JailedDocument.php
@@ -42,7 +42,7 @@ class JailedDocument implements \ArrayAccess, \IteratorAggregate, \JsonSerializa
         // White listed functions will always be getter functions, so somehow get the name of a possible getter function
         // name.
         $lcName = lcfirst($name);
-        $getFxnCall = ($lcName[0] === 'g' && strpos($lcName, 'get') === 0) ? $lcName : sprintf('get%s', ucfirst($name));
+        $getFxnCall = ($lcName[0] === '_' || strpos($lcName, 'get') === 0) ? $lcName : sprintf('get%s', ucfirst($name));
 
         // Check if our function call is a jailed call, meaning the function should be mapped to special "jailed"
         // jailed version of the function call.
@@ -67,9 +67,9 @@ class JailedDocument implements \ArrayAccess, \IteratorAggregate, \JsonSerializa
      *
      * @return bool
      */
-    public function coreInstanceOf($class)
+    public function _coreInstanceOf($class)
     {
-        return is_subclass_of($this->object, $class);
+        return ($this->object instanceof $class) || is_subclass_of($this->object, $class);
     }
 
     ///

--- a/src/allejo/stakx/Document/RepeaterPageView.php
+++ b/src/allejo/stakx/Document/RepeaterPageView.php
@@ -32,6 +32,26 @@ class RepeaterPageView extends BasePageView implements TemplateReadyDocument
     }
 
     /**
+     * Get the permalink matching all the placeholders for a Repeater.
+     *
+     * @param array $where
+     *
+     * @return null|string
+     */
+    public function _getPermalinkWhere(array $where)
+    {
+        foreach ($this->permalinks as $expandedValue)
+        {
+            if ($expandedValue->getIterators() === $where)
+            {
+                return $expandedValue->getEvaluated();
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Get the expanded values for the permalinks to this PageView.
      *
      * @return ExpandedValue[]
@@ -95,7 +115,11 @@ class RepeaterPageView extends BasePageView implements TemplateReadyDocument
      */
     public function createJail()
     {
-        return new JailedDocument($this, self::$whiteListedFunctions);
+        $whitelist = array_merge(self::$whiteListedFunctions, [
+            '_getPermalinkWhere',
+        ]);
+
+        return new JailedDocument($this, $whitelist);
     }
 
     /**

--- a/src/allejo/stakx/Manager/PageManager.php
+++ b/src/allejo/stakx/Manager/PageManager.php
@@ -36,6 +36,8 @@ class PageManager extends TrackingManager
 {
     /** @var StaticPageView[] A place to store a reference to static PageViews with titles. */
     private $staticPages;
+    /** @var RepeaterPageView[] A place to store a reference to repeater PageViews with titles. */
+    private $repeaterPages;
     private $configuration;
     private $collectionManager;
     private $dataManager;
@@ -58,6 +60,7 @@ class PageManager extends TrackingManager
             BasePageView::REPEATER_TYPE => [],
         ];
         $this->staticPages = [];
+        $this->repeaterPages = [];
         $this->configuration = $configuration;
         $this->collectionManager = $collectionManager;
         $this->dataManager = $dataManager;
@@ -157,6 +160,21 @@ class PageManager extends TrackingManager
         foreach ($this->staticPages as $key => $value)
         {
             $jailedObjects[$key] = $value->createJail();
+        }
+
+        return $jailedObjects;
+    }
+
+    /**
+     * Get the jailed version of repeater PageViews indexed by their title.
+     */
+    public function getJailedRepeaterPageViews()
+    {
+        $jailedObjects = [];
+
+        foreach ($this->repeaterPages as $key => $value)
+        {
+            $jailedObjects[$key]= $value->createJail();
         }
 
         return $jailedObjects;
@@ -315,5 +333,12 @@ class PageManager extends TrackingManager
             'site' => $this->configuration->getConfiguration(),
         ]);
         $pageView->configurePermalinks();
+
+        if (empty($pageView['title']))
+        {
+            return;
+        }
+
+        $this->repeaterPages[$pageView['title']] = &$pageView;
     }
 }

--- a/src/allejo/stakx/Templating/Twig/Extension/BaseUrlFunction.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/BaseUrlFunction.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\Templating\Twig\Extension;
 
+use allejo\stakx\Document\JailedDocument;
+use allejo\stakx\Document\RepeaterPageView;
 use allejo\stakx\Service;
 use Twig_Environment;
 
@@ -14,14 +16,14 @@ class BaseUrlFunction extends AbstractTwigExtension implements TwigFunctionInter
 {
     private $site;
 
-    public function __invoke(Twig_Environment $env, $assetPath, $absolute = false)
+    public function __invoke(Twig_Environment $env, $assetPath, $absolute = false, $params = [])
     {
         $globals = $env->getGlobals();
         $this->site = $globals['site'];
 
         $url = $this->getUrl($absolute);
         $baseURL = $this->getBaseUrl();
-        $permalink = $this->guessAssetPath($assetPath);
+        $permalink = $this->guessAssetPath($assetPath, $params);
 
         return $this->buildPermalink($url, $baseURL, $permalink);
     }
@@ -66,9 +68,14 @@ class BaseUrlFunction extends AbstractTwigExtension implements TwigFunctionInter
         return $base;
     }
 
-    private function guessAssetPath($assetPath)
+    private function guessAssetPath($assetPath, $params)
     {
-        if (is_array($assetPath) || ($assetPath instanceof \ArrayAccess))
+        if ($assetPath instanceof JailedDocument && $assetPath->_coreInstanceOf(RepeaterPageView::class))
+        {
+            /** @var RepeaterPageView $assetPath */
+            return ($link = $assetPath->_getPermalinkWhere($params)) ? $link : '/';
+        }
+        elseif (is_array($assetPath) || ($assetPath instanceof \ArrayAccess))
         {
             return (isset($assetPath['permalink'])) ? $assetPath['permalink'] : '/';
         }


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Fixes #77

### Description

Allow the `url()` Twig function to link to named repeater PageViews.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
