### PR TITLE
Ignore underscore folders inside of themes

### DIFF
--- a/example/_themes/bootstrap/secret.txt
+++ b/example/_themes/bootstrap/secret.txt
@@ -1,0 +1,1 @@
+the answer to life is 42

--- a/src/allejo/stakx/Configuration.php
+++ b/src/allejo/stakx/Configuration.php
@@ -32,7 +32,7 @@ class Configuration
      *
      * @var array
      */
-    public static $stakxSourceFiles = ['/^_(?!themes).*/', '/.twig$/'];
+    public static $stakxSourceFiles = ['/^_(?!themes)/', '/.twig$/'];
 
     /**
      * An array representation of the main Yaml configuration.

--- a/src/allejo/stakx/Filesystem/FileExplorer.php
+++ b/src/allejo/stakx/Filesystem/FileExplorer.php
@@ -12,7 +12,7 @@ namespace allejo\stakx\Filesystem;
  *
  * This class is the macOS Finder or Windows Explorer equivalent for stakx. New instances of this class should only be
  * created through the `FileExplorer::create()` helper function. To access the file iterator from this instance, use
- * `FileExplorer::getExplorer()` to retrieve File objects.
+ * `FileExplorer::getFileIterator()` to retrieve File objects.
  *
  * @internal
  */
@@ -133,11 +133,11 @@ class FileExplorer extends \RecursiveFilterIterator implements \Iterator
     }
 
     /**
-     * Get an Iterator with all of the files that have met the search requirements.
+     * Get an Iterator with all of the files (and *only* files) that have met the search requirements.
      *
      * @return \RecursiveIteratorIterator
      */
-    public function getExplorer()
+    public function getFileIterator()
     {
         return new \RecursiveIteratorIterator($this);
     }

--- a/src/allejo/stakx/Manager/AssetManager.php
+++ b/src/allejo/stakx/Manager/AssetManager.php
@@ -67,6 +67,8 @@ class AssetManager extends TrackingManager
      */
     public function copyFiles()
     {
+        $this->logger->notice('Copying asset files...');
+
         $this->scanTrackableItems(
             Service::getWorkingDirectory(),
             [

--- a/src/allejo/stakx/Manager/ThemeManager.php
+++ b/src/allejo/stakx/Manager/ThemeManager.php
@@ -33,7 +33,10 @@ class ThemeManager extends AssetManager
         $this->themeName = $themeName;
         $this->themeFile = fs::appendPath($this->themeFolder, self::THEME_DEFINITION_FILE);
         $this->themeData = [
-            'exclude' => [],
+            'exclude' => [
+                // Ignore underscore directories inside of our theme folder
+                sprintf("/_themes\/%s\/_/", $this->themeName)
+            ],
             'include' => [],
         ];
 

--- a/src/allejo/stakx/Manager/TrackingManager.php
+++ b/src/allejo/stakx/Manager/TrackingManager.php
@@ -245,7 +245,7 @@ abstract class TrackingManager extends BaseManager
 
         $fileExplorerFlags = array_key_exists('fileExplorer', $options) ? $options['fileExplorer'] : null;
         $this->fileExplorer = FileExplorer::create($path, $excludes, $includes, $fileExplorerFlags);
-        $fileExplorer = $this->fileExplorer->getExplorer();
+        $fileExplorer = $this->fileExplorer->getFileIterator();
 
         foreach ($fileExplorer as $file)
         {

--- a/tests/allejo/stakx/Test/Filesystem/FileExplorerTest.php
+++ b/tests/allejo/stakx/Test/Filesystem/FileExplorerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * @copyright 2018 Vladimir Jimenez
+ * @license   https://github.com/stakx-io/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Test\Filesystem;
+
+use allejo\stakx\Filesystem\FileExplorer;
+use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
+use org\bovigo\vfs\vfsStream;
+
+class FileExplorerTest extends PHPUnit_Stakx_TestCase
+{
+    public function testFindAllFilesDefaultBehavior()
+    {
+        $filesystem = [
+            '_config.yml' => '',
+            'README.md' => '',
+            'LICENSE.MD' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url())->getFileIterator();
+        $count = 0;
+
+        foreach ($explorer as $file)
+        {
+            $this->assertArrayHasKey($file->getFilename(), $filesystem);
+            $count++;
+        }
+
+        $this->assertEquals(count($filesystem), $count);
+    }
+
+    public function testDotFilesNotIncludedByDefault()
+    {
+        $filesystem = [
+            '.cache' => '',
+            '.htaccess' => '',
+            '.something' => '',
+            'README.md' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url())->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertNotEquals('.', $file->getFilename()[0]);
+        }
+    }
+
+    public function testDotFilesIncludedWithFlag()
+    {
+        $filesystem = [
+            '.cache' => '',
+            '.htaccess' => '',
+            '.something' => '',
+            'README.md' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url(), [], [], FileExplorer::ALLOW_DOT_FILES)->getFileIterator();
+
+        $this->assertCount(count($filesystem), $explorer);
+    }
+
+    public function testIncludeOnlyFilesEmpty()
+    {
+        $filesystem = [
+            '.htaccess' => '',
+            '_config.yml' => '',
+            'README.md' => '',
+            'LICENSE.MD' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url(), [], [], FileExplorer::INCLUDE_ONLY_FILES)->getFileIterator();
+
+        $this->assertCount(0, $explorer);
+    }
+
+    public function testIncludeOnlyFiles()
+    {
+        $filesystem = [
+            '.htaccess' => '',
+            '_config.yml' => '',
+            'README.md' => '',
+            'LICENSE.MD' => '',
+        ];
+        $includes = [
+            '.htaccess',
+            'README.md',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url(), [], $includes, FileExplorer::INCLUDE_ONLY_FILES)->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertContains($file->getFilename(), $includes);
+        }
+
+        $this->assertCount(count($includes), $explorer);
+    }
+
+    public function testExcludingFiles()
+    {
+        $filesystem = [
+            '_config.yml' => '',
+            'README.md' => '',
+            'LICENSE.md' => '',
+            'index.html' => '',
+            'feed.xml' => '',
+        ];
+        $exclusion = [
+            'README.md',
+            'index.html',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url(), $exclusion)->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertNotContains($file->getFilename(), $exclusion);
+        }
+
+        $this->assertCount(count($filesystem) - count($exclusion), $explorer);
+    }
+
+    public function testFindingDirectories()
+    {
+        $filesystem = [
+            '_posts' => [],
+            'README.md' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url());
+
+        foreach ($explorer as $file)
+        {
+            if ($file->getFilename() === '_posts')
+            {
+                $this->assertTrue($file->isDir());
+            }
+            else
+            {
+                $this->assertTrue($file->isFile());
+            }
+        }
+
+        $this->assertCount(count($filesystem), $explorer);
+    }
+
+    public function testIgnoringDirectories()
+    {
+        $filesystem = [
+            '_posts' => [],
+            'README.md' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url(), [], [], FileExplorer::IGNORE_DIRECTORIES)->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertTrue($file->isFile());
+        }
+
+        $this->assertCount(1, $explorer);
+    }
+
+    public function testFindingFilesInSubdirectories()
+    {
+        $filesystem = [
+            '_posts' => [
+                'hello-world.md' => '',
+                'about-me.md' => '',
+            ],
+            'README.md' => '',
+        ];
+
+        vfsStream::create($filesystem);
+
+        $explorer = FileExplorer::create($this->rootDir->url())->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertTrue($file->isFile());
+        }
+
+        $this->assertCount(3, $explorer);
+    }
+
+    public function testExcludingPatterns()
+    {
+        $excluded = [
+            'index.html.twig' => '',
+            'about.html.twig' => '',
+            'contact.html.twig' => '',
+        ];
+        $baseFiles = [
+            'README.md' => '',
+            'LICENSE.md' => '',
+        ];
+
+        vfsStream::create(array_merge($excluded, $baseFiles));
+
+        $explorer = FileExplorer::create($this->rootDir->url(), ['/\.twig$/'])->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertArrayHasKey($file->getFilename(), $baseFiles);
+        }
+
+        $this->assertCount(count($baseFiles), $explorer);
+    }
+
+    public function testIncludingPatternsOnly()
+    {
+        $included = [
+            'index.html.twig' => '',
+            'about.html.twig' => '',
+            'contact.html.twig' => '',
+        ];
+        $baseFiles = [
+            'README.md' => '',
+            'LICENSE.md' => '',
+        ];
+
+        vfsStream::create(array_merge($included, $baseFiles));
+
+        $explorer = FileExplorer::create($this->rootDir->url(), [], ['/\.twig$/'], FileExplorer::INCLUDE_ONLY_FILES)->getFileIterator();
+
+        foreach ($explorer as $file)
+        {
+            $this->assertArrayNotHasKey($file->getFilename(), $baseFiles);
+        }
+
+        $this->assertCount(count($included), $explorer);
+    }
+}


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Fixes #85 

### Description

Underscore folders are not ignored when inside of theme folders because of the way the main regex ignores the `_themes` folder to allow copying over assets from a theme. This PR adds a new regex for ignoring underscore folders inside of active theme.

This also adds unit tests for the FileExplorer class since I thought I was going to be making changes to it but nope. They're still nice to have.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
