### PR TITLE
Cache Sass AST when using '--use-cache'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.2
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.5
       env: dependencies=highest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,9 @@ environment:
     - dependencies: highest
       php_ver_target: 7.2
 
+matrix:
+  fast_finish: true
+
 branches:
   except:
     - gh-pages

--- a/src/allejo/stakx/AssetEngine/AssetEngineInterface.php
+++ b/src/allejo/stakx/AssetEngine/AssetEngineInterface.php
@@ -7,6 +7,7 @@
 
 namespace allejo\stakx\AssetEngine;
 
+use allejo\stakx\Filesystem\Folder;
 use allejo\stakx\Manager\PageManager;
 
 /**
@@ -17,7 +18,18 @@ interface AssetEngineInterface
     const CONTAINER_TAG = 'stakx.asset_engine';
 
     /**
-     * The section name in a site's `_config.yml` where this engine can be configured.
+     * A unique-ish name used to identify this asset engine.
+     *
+     * This name will be used as an identity throughout stakx's internals and
+     * for naming related cache folders.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * The section name in a site's `_config.yml` where this engine can be
+     * configured.
      *
      * @return string
      */
@@ -63,6 +75,9 @@ interface AssetEngineInterface
     /**
      * Set custom options used internally by this AssetEngine.
      *
+     * These options are a union of the default configuration and any overrides
+     * from the site configuration file.
+     *
      * @param array $options
      *
      * @since 0.2.0
@@ -72,11 +87,46 @@ interface AssetEngineInterface
     public function setOptions(array $options);
 
     /**
-     * Set the PageManager for this AssetEngine so it can be available if it's available.
+     * Set the PageManager for this AssetEngine so it can be available if it's
+     * available.
      *
      * @param PageManager $pageManager
+     *
+     * @since 0.2.0
      *
      * @return void
      */
     public function setPageManager(PageManager $pageManager);
+
+    /**
+     * Perform loading cache operations before this engine's parsing functionality
+     * is called.
+     *
+     * Any cache-able information should be read from files in the given Folder
+     * and unserialize()'d into this engine's properties.
+     *
+     * This function is only called when stakx is using the `--use-cache` flag.
+     *
+     * @param Folder $cacheDir
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function loadCache(Folder $cacheDir);
+
+    /**
+     * Perform any saving of caches after the parsing functionality has been
+     * called.
+     *
+     * Any cache-able information should be serialize()'d and written to a file
+     * in the given Folder.
+     *
+     * @param Folder $cacheDir
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function saveCache(Folder $cacheDir);
 }

--- a/src/allejo/stakx/AssetEngine/Sass/Compiler.php
+++ b/src/allejo/stakx/AssetEngine/Sass/Compiler.php
@@ -29,7 +29,10 @@ class Compiler extends BaseCompiler
      */
     protected function importFile($path, $out)
     {
-        if (!Service::hasRunTimeFlag(RuntimeStatus::IN_SERVE_MODE))
+        $serveMode = Service::hasRunTimeFlag(RuntimeStatus::IN_SERVE_MODE);
+        $cacheMode = Service::hasRunTimeFlag(RuntimeStatus::USING_CACHE);
+
+        if (!($serveMode || $cacheMode))
         {
             parent::importFile($path, $out);
 

--- a/src/allejo/stakx/AssetEngine/Sass/Compiler.php
+++ b/src/allejo/stakx/AssetEngine/Sass/Compiler.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright 2018 Vladimir Jimenez
+ * @license   https://github.com/stakx-io/stakx/blob/master/LICENSE.md MIT
+ */
+
 namespace allejo\stakx\AssetEngine\Sass;
 
 use allejo\stakx\RuntimeStatus;
@@ -72,8 +77,10 @@ class Compiler extends BaseCompiler
      */
     public function clearImportCache($file = null)
     {
-        if ($file === null) {
+        if ($file === null)
+        {
             $this->importCache = [];
+
             return;
         }
 

--- a/src/allejo/stakx/AssetEngine/Sass/SassEngine.php
+++ b/src/allejo/stakx/AssetEngine/Sass/SassEngine.php
@@ -15,7 +15,6 @@ use allejo\stakx\Document\StaticPageView;
 use allejo\stakx\Filesystem\FilesystemLoader as fs;
 use allejo\stakx\Filesystem\Folder;
 use allejo\stakx\Manager\PageManager;
-use allejo\stakx\RuntimeStatus;
 use allejo\stakx\Service;
 use Leafo\ScssPhp\Formatter\Compact;
 use Leafo\ScssPhp\Formatter\Crunched;
@@ -155,7 +154,7 @@ class SassEngine implements AssetEngineInterface
         ;
 
         $cache = serialize([
-            $this->compiler
+            $this->compiler,
         ]);
 
         file_put_contents($cachePath, $cache);

--- a/src/allejo/stakx/AssetEngine/Sass/SassEngine.php
+++ b/src/allejo/stakx/AssetEngine/Sass/SassEngine.php
@@ -13,7 +13,9 @@ use allejo\stakx\Configuration;
 use allejo\stakx\Document\BasePageView;
 use allejo\stakx\Document\StaticPageView;
 use allejo\stakx\Filesystem\FilesystemLoader as fs;
+use allejo\stakx\Filesystem\Folder;
 use allejo\stakx\Manager\PageManager;
+use allejo\stakx\RuntimeStatus;
 use allejo\stakx\Service;
 use Leafo\ScssPhp\Formatter\Compact;
 use Leafo\ScssPhp\Formatter\Crunched;
@@ -22,6 +24,8 @@ use Leafo\ScssPhp\Formatter\Nested;
 
 class SassEngine implements AssetEngineInterface
 {
+    const CACHE_FILE = 'sass_engine.cache';
+
     private $fileSourceMap = false;
     private $configuration;
     /** @var PageManager */
@@ -33,6 +37,11 @@ class SassEngine implements AssetEngineInterface
     {
         $this->configuration = $configuration;
         $this->compiler = new Compiler();
+    }
+
+    public function getName()
+    {
+        return 'Sass';
     }
 
     public function getConfigurationNamespace()
@@ -121,6 +130,35 @@ class SassEngine implements AssetEngineInterface
     public function setPageManager(PageManager $pageManager)
     {
         $this->pageManager = $pageManager;
+    }
+
+    public function loadCache(Folder $cacheDir)
+    {
+        $cachePath = $cacheDir
+            ->getFilesystemPath()
+            ->appendToPath(self::CACHE_FILE)
+        ;
+
+        if (fs::exists($cachePath))
+        {
+            list(
+                $this->compiler
+            ) = unserialize(file_get_contents($cachePath));
+        }
+    }
+
+    public function saveCache(Folder $cacheDir)
+    {
+        $cachePath = $cacheDir
+            ->getFilesystemPath()
+            ->appendToPath(self::CACHE_FILE)
+        ;
+
+        $cache = serialize([
+            $this->compiler
+        ]);
+
+        file_put_contents($cachePath, $cache);
     }
 
     private function configureImportPath()

--- a/src/allejo/stakx/Console/Command/BuildCommand.php
+++ b/src/allejo/stakx/Console/Command/BuildCommand.php
@@ -125,6 +125,9 @@ class BuildCommand extends ContainerAwareCommand
 
         if ($input->getOption(self::SAFE_MODE))
         {
+            // Caches could be maliciously manipulated so disable reading the cache in safe mode
+            Service::removeRuntimeFlag(RuntimeStatus::USING_CACHE);
+
             Service::setRuntimeFlag(RuntimeStatus::IN_SAFE_MODE);
         }
 

--- a/src/allejo/stakx/Console/Command/ServeCommand.php
+++ b/src/allejo/stakx/Console/Command/ServeCommand.php
@@ -8,8 +8,8 @@
 namespace allejo\stakx\Console\Command;
 
 use allejo\stakx\RuntimeStatus;
-use allejo\stakx\Server\WebServer;
 use allejo\stakx\Server\RouteMapper;
+use allejo\stakx\Server\WebServer;
 use allejo\stakx\Service;
 use allejo\stakx\Website;
 use React\EventLoop\Factory;

--- a/src/allejo/stakx/Filesystem/File.php
+++ b/src/allejo/stakx/Filesystem/File.php
@@ -8,6 +8,7 @@
 namespace allejo\stakx\Filesystem;
 
 use allejo\stakx\Service;
+use allejo\stakx\Filesystem\FilesystemLoader as fs;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
 /**
@@ -38,7 +39,7 @@ final class File extends \SplFileInfo
     public function __construct($filePath)
     {
         $this->rawPath = $filePath;
-        $realPath = self::realpath($filePath);
+        $realPath = fs::realpath($filePath);
 
         if ($realPath === false)
         {
@@ -193,7 +194,7 @@ final class File extends \SplFileInfo
      */
     private function isSafeToRead()
     {
-        if (self::isVFS($this->getAbsolutePath()))
+        if (fs::isVFS($this->getAbsolutePath()))
         {
             return;
         }
@@ -214,27 +215,4 @@ final class File extends \SplFileInfo
         );
     }
 
-    /**
-     * A vfsStream friendly way of getting the realpath() of something.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    public static function realpath($path)
-    {
-        return self::isVFS($path) ? $path : realpath($path);
-    }
-
-    /**
-     * Check whether a given path is on the virtual filesystem.
-     *
-     * @param string $path
-     *
-     * @return bool
-     */
-    private static function isVFS($path)
-    {
-        return substr($path, 0, 6) == 'vfs://';
-    }
 }

--- a/src/allejo/stakx/Filesystem/FileExplorer.php
+++ b/src/allejo/stakx/Filesystem/FileExplorer.php
@@ -7,6 +7,8 @@
 
 namespace allejo\stakx\Filesystem;
 
+use allejo\stakx\Filesystem\FilesystemLoader as fs;
+
 /**
  * The core class to handle reading files from directories on the filesystem.
  *
@@ -185,7 +187,7 @@ class FileExplorer extends \RecursiveFilterIterator implements \Iterator
      */
     public static function create($folder, $excludes = [], $includes = [], $flags = null)
     {
-        $folder = File::realpath($folder);
+        $folder = fs::realpath($folder);
         $iterator = new \RecursiveDirectoryIterator($folder, \RecursiveDirectoryIterator::SKIP_DOTS);
 
         return new self($iterator, $excludes, $includes, $flags);

--- a/src/allejo/stakx/Filesystem/Filesystem.php
+++ b/src/allejo/stakx/Filesystem/Filesystem.php
@@ -229,4 +229,28 @@ class Filesystem extends \Symfony\Component\Filesystem\Filesystem
 
         return file_get_contents($path);
     }
+
+    /**
+     * A vfsStream friendly way of getting the realpath() of something.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function realpath($path)
+    {
+        return $this->isVFS($path) ? $path : realpath($path);
+    }
+
+    /**
+     * Check whether a given path is on the virtual filesystem.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function isVFS($path)
+    {
+        return substr($path, 0, 6) == 'vfs://';
+    }
 }

--- a/src/allejo/stakx/Filesystem/FilesystemLoader.php
+++ b/src/allejo/stakx/Filesystem/FilesystemLoader.php
@@ -14,7 +14,9 @@ namespace allejo\stakx\Filesystem;
  * @method static \string getInternalResource(\string $file)      Get the contents of a stakx resource file.
  * @method static \string getFolderPath(\string $path)            Get the parent directory of a given file.
  * @method static \string getRelativePath(\string $path)          Strip the current working directory from an absolute path.
+ * @method static \bool isVFS(\string $path)                      Check whether a given path is on the virtual filesystem.
  * @method static FilesystemPath path(\string $path)              Build a cross-platform ready filesystem path.
+ * @method static \bool realpath(\string $path)                   A vfsStream friendly way of getting the realpath() of something.
  * @method static \string removeExtension(\string $path)          Get the full path to the file without the extension.
  */
 abstract class FilesystemLoader

--- a/src/allejo/stakx/Filesystem/FilesystemPath.php
+++ b/src/allejo/stakx/Filesystem/FilesystemPath.php
@@ -50,6 +50,8 @@ final class FilesystemPath
      * Append a path to a directory path.
      *
      * @param string $append The path to append
+     *
+     * @return self
      */
     public function appendToPath($append)
     {
@@ -59,6 +61,8 @@ final class FilesystemPath
         }
 
         $this->absolutePath = $this->buildPath($this->absolutePath, $this->unixifyPath($append));
+
+        return $this;
     }
 
     /**

--- a/src/allejo/stakx/Filesystem/FilesystemPath.php
+++ b/src/allejo/stakx/Filesystem/FilesystemPath.php
@@ -23,6 +23,8 @@ final class FilesystemPath
     private $originalPath;
     /** @var bool */
     private $isWindows;
+    /** @var bool */
+    private $isVFS;
 
     /**
      * @param FilesystemPath|string $filePath
@@ -34,6 +36,7 @@ final class FilesystemPath
 
         $this->originalPath = $filePath;
         $this->isWindows = ($dirSep === '\\');
+        $this->isVFS = fs::isVFS($filePath);
 
         if ($this->isWindows)
         {
@@ -88,7 +91,7 @@ final class FilesystemPath
      */
     public function getAbsolutePath()
     {
-        if ($this->isWindows)
+        if (!$this->isVFS && $this->isWindows)
         {
             return str_replace('/', '\\', $this->absolutePath);
         }

--- a/src/allejo/stakx/Filesystem/FilesystemPath.php
+++ b/src/allejo/stakx/Filesystem/FilesystemPath.php
@@ -25,11 +25,13 @@ final class FilesystemPath
     private $isWindows;
 
     /**
-     * @param string $filePath
-     * @param string $dirSep
+     * @param FilesystemPath|string $filePath
+     * @param string                $dirSep
      */
     public function __construct($filePath, $dirSep = DIRECTORY_SEPARATOR)
     {
+        $filePath = (string)$filePath;
+
         $this->originalPath = $filePath;
         $this->isWindows = ($dirSep === '\\');
 

--- a/src/allejo/stakx/Filesystem/Folder.php
+++ b/src/allejo/stakx/Filesystem/Folder.php
@@ -15,6 +15,9 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException;
  */
 final class Folder
 {
+    /** @var boolean */
+    private $frozen;
+
     /** @var FilesystemPath */
     private $folder;
 
@@ -23,6 +26,7 @@ final class Folder
      */
     public function __construct($folderPath)
     {
+        $this->frozen = false;
         $this->folder = new FilesystemPath($folderPath);
 
         if (!$this->folder->isDir())
@@ -37,14 +41,51 @@ final class Folder
     }
 
     /**
+     * Get the file path to this Folder in an OOP friendly way.
+     *
+     * @return FilesystemPath
+     */
+    public function getFilesystemPath()
+    {
+        return new FilesystemPath($this->__toString());
+    }
+
+    /**
+     * Set this Folder to a "frozen" state meaning its path can no longer be modified.
+     */
+    public function freeze()
+    {
+        $this->frozen = true;
+    }
+
+    /**
+     * Check whether or not this Folder's path has been frozen.
+     *
+     * @return bool
+     */
+    public function isFrozen()
+    {
+        return $this->frozen;
+    }
+
+    /**
      * Set a base folder that will be prefixed before all file writes and copies.
      *
      * @param string $folderName
      *
+     * @since 0.2.0 An \Exception is thrown when a frozen Folder is attempted to
+     *              be modified
      * @since 0.1.0
+     *
+     * @throws \Exception
      */
     public function setTargetDirectory($folderName)
     {
+        if ($this->isFrozen())
+        {
+            throw new \Exception('A frozen folder object cannot be modified.');
+        }
+
         if ($folderName === null || empty($folderName))
         {
             return;

--- a/src/allejo/stakx/Filesystem/Folder.php
+++ b/src/allejo/stakx/Filesystem/Folder.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException;
  */
 final class Folder
 {
-    /** @var boolean */
+    /** @var bool */
     private $frozen;
 
     /** @var FilesystemPath */

--- a/src/allejo/stakx/Manager/ThemeManager.php
+++ b/src/allejo/stakx/Manager/ThemeManager.php
@@ -35,7 +35,7 @@ class ThemeManager extends AssetManager
         $this->themeData = [
             'exclude' => [
                 // Ignore underscore directories inside of our theme folder
-                sprintf("/_themes\/%s\/_/", $this->themeName)
+                sprintf("/_themes\/%s\/_/", $this->themeName),
             ],
             'include' => [],
         ];

--- a/src/allejo/stakx/Server/WebServer.php
+++ b/src/allejo/stakx/Server/WebServer.php
@@ -8,7 +8,6 @@
 namespace allejo\stakx\Server;
 
 use allejo\stakx\Compiler;
-use allejo\stakx\Exception\FileAwareException;
 use allejo\stakx\Filesystem\File;
 use allejo\stakx\Filesystem\FilesystemPath;
 use allejo\stakx\Service;
@@ -77,7 +76,8 @@ class WebServer
                 case Dispatcher::FOUND:
                     $urlPlaceholders = isset($routeInfo[2]) ? $routeInfo[2] : [];
 
-                    try {
+                    try
+                    {
                         return $routeInfo[1]($request, ...array_values($urlPlaceholders));
                     }
                     catch (\Exception $e)

--- a/src/allejo/stakx/Service.php
+++ b/src/allejo/stakx/Service.php
@@ -33,6 +33,11 @@ abstract class Service
         self::$runTimeStatus |= $status;
     }
 
+    public static function removeRuntimeFlag($status)
+    {
+        self::$runTimeStatus &= ~$status;
+    }
+
     public static function resetRuntimeFlags()
     {
         self::$runTimeStatus = 0;

--- a/src/allejo/stakx/Templating/Twig/TwigFileLoader.php
+++ b/src/allejo/stakx/Templating/Twig/TwigFileLoader.php
@@ -18,7 +18,7 @@ class TwigFileLoader extends \Twig_Loader_Filesystem
 
         if (Service::hasRunTimeFlag(RuntimeStatus::IN_SERVE_MODE))
         {
-            return sprintf("%s_%s", $template, filemtime($template));
+            return sprintf('%s_%s', $template, filemtime($template));
         }
 
         return $template;

--- a/src/allejo/stakx/Templating/Twig/TwigStakxBridge.php
+++ b/src/allejo/stakx/Templating/Twig/TwigStakxBridge.php
@@ -41,7 +41,7 @@ class TwigStakxBridge implements TemplateBridgeInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function clearTemplateCache()
     {

--- a/tests/allejo/stakx/Test/AssetEngine/SassEngineTest.php
+++ b/tests/allejo/stakx/Test/AssetEngine/SassEngineTest.php
@@ -147,6 +147,7 @@ SASS;
     {
         Service::setWorkingDirectory($this->rootDir->url());
         vfsStream::create([
+            '.stakx-cache' => [],
             '_sass' => [
                 'styles.scss.twig' => $this->buildFrontMatterTemplate(['permalink' => '/styles.css'], $this->sass),
             ],

--- a/tests/allejo/stakx/Test/Filesystem/FileExplorerTest.php
+++ b/tests/allejo/stakx/Test/Filesystem/FileExplorerTest.php
@@ -29,7 +29,7 @@ class FileExplorerTest extends PHPUnit_Stakx_TestCase
         foreach ($explorer as $file)
         {
             $this->assertArrayHasKey($file->getFilename(), $filesystem);
-            $count++;
+            ++$count;
         }
 
         $this->assertEquals(count($filesystem), $count);


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Fixes #90

### Description

Add caching functions to asset engines that'll let you read and write to the `.stakx-cache/` folder.

### Check List

- [x] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
