### PR TITLE
Use the Symfony Router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "leafo/scssphp": "^0.7.6",
     "maciejczyzewski/bottomline": "dev-master",
     "mikey179/vfsStream": "^1.6.4",
-    "nikic/fast-route": "^1.3",
     "psr/log": "^1.0.2",
     "react/http": "^0.8.3",
     "scrivo/highlight.php": "^9.12",
@@ -40,6 +39,7 @@
     "symfony/event-dispatcher": "^3.4.0",
     "symfony/filesystem": "^3.4.0",
     "symfony/finder": "^3.4.0",
+    "symfony/routing": "^3.4",
     "symfony/yaml": "^3.4.0",
     "twig/twig": "^1.26"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b765047b8275c542282c5434445d9177",
+    "content-hash": "e59b2038902d6a9b30ae9001ac27ee56",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -300,12 +300,12 @@
             "version": "v1.6.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },
@@ -340,52 +340,6 @@
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
             "time": "2017-08-01T08:02:14+00:00"
-        },
-        {
-            "name": "nikic/fast-route",
-            "version": "v1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/FastRoute.git",
-                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
-                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35|~5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "FastRoute\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov",
-                    "email": "nikic@php.net"
-                }
-            ],
-            "description": "Fast request router for PHP",
-            "keywords": [
-                "router",
-                "routing"
-            ],
-            "time": "2018-02-13T20:26:39+00:00"
         },
         {
             "name": "psr/container",
@@ -1614,6 +1568,82 @@
                 "shim"
             ],
             "time": "2018-09-21T13:07:52+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v3.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "ff11aac46d6cb8a65f2855687bb9a1ac9d860eec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/ff11aac46d6cb8a65f2855687bb9a1ac9d860eec",
+                "reference": "ff11aac46d6cb8a65f2855687bb9a1ac9d860eec",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.1",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "psr/log": "~1.0",
+                "symfony/config": "^3.3.1|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation loader",
+                "symfony/config": "For using the all-in-one router or any loader",
+                "symfony/expression-language": "For using expression matching",
+                "symfony/http-foundation": "For using a Symfony Request object",
+                "symfony/yaml": "For using the YAML loader"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Routing Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "time": "2019-03-29T21:58:42+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/allejo/stakx/Server/Controller.php
+++ b/src/allejo/stakx/Server/Controller.php
@@ -239,7 +239,7 @@ class Controller
 
             // Find the name of the last route parameter, if one exists
             $results = [];
-            preg_match('/{(.+)}\/$/', $routeUrl, $results);
+            preg_match('/{(.+)}\/?$/', $routeUrl, $results);
 
             // Allow the last route parameter to have `/` in the permalink that's not part of the route itself
             //   see https://github.com/stakx-io/stakx/issues/98

--- a/src/allejo/stakx/Server/Controller.php
+++ b/src/allejo/stakx/Server/Controller.php
@@ -237,7 +237,23 @@ class Controller
             $routeName = $pageView->getRelativeFilePath();
             $routeName = preg_replace('/[\/\.]/', '_', $routeName);
 
-            $route = new Route($routeUrl, ['_controller' => $dispatcher->createAction($pageView, $compiler)]);
+            // Find the name of the last route parameter, if one exists
+            $results = [];
+            preg_match('/{(.+)}\/$/', $routeUrl, $results);
+
+            // Allow the last route parameter to have `/` in the permalink that's not part of the route itself
+            //   see https://github.com/stakx-io/stakx/issues/98
+            $requirements = [];
+            if (count($results) >= 2)
+            {
+                $requirements[$results[1]] = '.+';
+            }
+
+            $route = new Route(
+                $routeUrl,
+                ['_controller' => $dispatcher->createAction($pageView, $compiler)],
+                $requirements
+            );
 
             $router->add($routeName, $route);
         }

--- a/src/allejo/stakx/Server/Controller.php
+++ b/src/allejo/stakx/Server/Controller.php
@@ -246,7 +246,7 @@ class Controller
             $requirements = [];
             if (count($results) >= 2)
             {
-                $requirements[$results[1]] = '.+';
+                $requirements[$results[1]] = '.*';
             }
 
             $route = new Route(

--- a/src/allejo/stakx/Server/RouteMapper.php
+++ b/src/allejo/stakx/Server/RouteMapper.php
@@ -16,13 +16,20 @@ use allejo\stakx\FrontMatter\FrontMatterParser;
 
 class RouteMapper
 {
+    /** @var string[] */
     private $redirects;
+
+    /** @var string */
     private $baseUrl;
+
+    /** @var BasePageView[] */
     private $mapping;
 
     public function __construct()
     {
+        $this->redirects = [];
         $this->mapping = [];
+        $this->baseUrl = '';
     }
 
     public function getBaseUrl()


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Fixes #98

### Description

This PR swaps out nikic's FastRoute with Symfony's Router. This router allows for configuration to allow `/` to exist as route parameters which solves the problem shown in #98.

In our web server controller, routes are now being modified to allow `/`s but only in the last route parameter.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
