### PR TITLE
Add new `case_insensitive` flag to order filter

### DIFF
--- a/src/allejo/stakx/Templating/Twig/Extension/OrderFilter.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/OrderFilter.php
@@ -12,16 +12,22 @@ use Twig\TwigFilter;
 
 class OrderFilter extends AbstractTwigExtension implements TwigFilterInterface
 {
-    public function __invoke($array, $key, $order = 'ASC')
+    public function __invoke($array, $key, $order = 'ASC', $case_insensitive = false)
     {
         if (!is_array($array))
         {
             return $array;
         }
 
-        usort($array, function ($a, $b) use ($key, $order) {
+        usort($array, function ($a, $b) use ($key, $order, $case_insensitive) {
             $aValue = __::get($a, $key);
             $bValue = __::get($b, $key);
+
+            if ($case_insensitive)
+            {
+                $aValue = strtolower($aValue);
+                $bValue = strtolower($bValue);
+            }
 
             if ($aValue == $bValue)
             {

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/OrderFilterTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/OrderFilterTest.php
@@ -29,6 +29,10 @@ class OrderFilterTest extends PHPUnit_Stakx_TestCase
                         'name' => 'Side order of fries',
                         'sort' => 3,
                     ],
+                    [
+                        'name' => 'super size me',
+                        'sort' => 10,
+                    ],
                 ],
             ],
         ];
@@ -51,6 +55,10 @@ class OrderFilterTest extends PHPUnit_Stakx_TestCase
             [
                 'name' => 'Side order of fries',
                 'sort' => 3,
+            ],
+            [
+                'name' => 'super size me',
+                'sort' => 10,
             ],
             [
                 'name' => 'Order of Bacon',
@@ -76,12 +84,140 @@ class OrderFilterTest extends PHPUnit_Stakx_TestCase
                 'sort' => 30,
             ],
             [
+                'name' => 'super size me',
+                'sort' => 10,
+            ],
+            [
                 'name' => 'Side order of fries',
                 'sort' => 3,
             ],
             [
                 'name' => 'Whee',
                 'sort' => 0,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider dataProvider_singleLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterAscOnArrayCaseSensitive($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'name', 'ASC');
+        $expected = [
+            [
+                'name' => 'Order of Bacon',
+                'sort' => 30,
+            ],
+            [
+                'name' => 'Side order of fries',
+                'sort' => 3,
+            ],
+            [
+                'name' => 'Whee',
+                'sort' => 0,
+            ],
+            [
+                'name' => 'super size me',
+                'sort' => 10,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider dataProvider_singleLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterDescOnArrayCaseSensitive($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'name', 'DESC');
+        $expected = [
+            [
+                'name' => 'super size me',
+                'sort' => 10,
+            ],
+            [
+                'name' => 'Whee',
+                'sort' => 0,
+            ],
+            [
+                'name' => 'Side order of fries',
+                'sort' => 3,
+            ],
+            [
+                'name' => 'Order of Bacon',
+                'sort' => 30,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider dataProvider_singleLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterAscOnArrayCaseInsensitive($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'name', 'ASC', true);
+        $expected = [
+            [
+                'name' => 'Order of Bacon',
+                'sort' => 30,
+            ],
+            [
+                'name' => 'Side order of fries',
+                'sort' => 3,
+            ],
+            [
+                'name' => 'super size me',
+                'sort' => 10,
+            ],
+            [
+                'name' => 'Whee',
+                'sort' => 0,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider dataProvider_singleLevelArray
+     *
+     * @param array $dataset
+     */
+    public function testOrderFilterDescOnArrayCaseInsensitive($dataset)
+    {
+        $orderFilter = new OrderFilter();
+        $result = $orderFilter($dataset, 'name', 'DESC', true);
+        $expected = [
+            [
+                'name' => 'Whee',
+                'sort' => 0,
+            ],
+            [
+                'name' => 'super size me',
+                'sort' => 10,
+            ],
+            [
+                'name' => 'Side order of fries',
+                'sort' => 3,
+            ],
+            [
+                'name' => 'Order of Bacon',
+                'sort' => 30,
             ],
         ];
 


### PR DESCRIPTION
### Summary

| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| BC breaks?     | no
| Deprecations?  | no
| Fixed issues   | N/A
| Target Version | v0.2.1

### Description

<!--
  - Describe what bug or issue your pull request is fixing.
  - Describe what new features your pull request are introducing.
-->

Add a new `case_insensitive` flag for the `order` Twig filter that will let you order an array of strings case-insensitively.

### Check List

- [ ] ~~Added appropriate PhpDoc for modifications~~
- [x] Added unit test to ensure fix works as intended
