### PR TITLE
Fix unit testing CI

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -1,7 +1,0 @@
-cd c:\tools\php*
-copy php.ini-production php.ini /Y
-echo date.timezone="UTC" >> php.ini
-echo extension_dir=ext >> php.ini
-echo extension=php_openssl.dll >> php.ini
-echo extension=php_mbstring.dll >> php.ini
-echo extension=php_fileinfo.dll >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,9 +44,23 @@ install:
   - sc config wuauserv start= auto
   - net start wuauserv
   - cinst -y OpenSSL.Light
-  - ps: cinst -y php --allow-empty-checksums --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]',''); cmd.exe /c 'appveyor.bat'
+
+  # In order to be able to list all the available PHP packages we have to
+  # downgrade Chocolatey to version 0.10.13.
+  # See https://github.com/chocolatey/choco/issues/1843
+  - ps: choco install chocolatey -y --version 0.10.13 --allow-downgrade --force
+  - ps: appveyor-retry choco install php --ignore-checksums -y --force --version ((choco search php -r --exact --all-versions| select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
+
+  - cd c:\tools\php*
+  - copy php.ini-production php.ini /Y
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - echo extension=php_mbstring.dll >> php.ini
+  - echo extension=php_fileinfo.dll >> php.ini
+
   - refreshenv
-  - cd C:\projects\stakx
+  - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar config github-oauth.github.com %GH_TOKEN%
   - IF %dependencies%==current php composer.phar install --no-progress --prefer-dist

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,11 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
+        bootstrap="tests/bootstrap.php"
         colors="true">
     <testsuites>
         <testsuite name="stakx Test Suite">
-            <directory suffix="Test.php" phpVersion="5.4.0" phpVersionOperator=">=">tests</directory>
+            <directory suffix="Test.php" phpVersion="5.6.0" phpVersionOperator=">=">tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
+++ b/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
@@ -37,7 +37,10 @@ class MarkdownEngine extends \ParsedownExtra implements MarkupEngineInterface
 
     protected function blockSetextHeader($Line, array $Block = null)
     {
-        $Block = parent::blockSetextHeader($Line, $Block);
+        // @TODO Remove this `@` operator in an update to Parsedown and ParsedownExtra
+        //   https://wiki.php.net/rfc/notice-for-non-valid-array-container
+        //   https://github.com/erusev/parsedown-extra/issues/134
+        $Block = @parent::blockSetextHeader($Line, $Block);
 
         if (isset($Block['element']['name']))
         {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+
+require __DIR__ . "/../vendor/autoload.php";
+
+// The only deprecation warnings we need to ignore/handle are in PHP 7.4 so far
+if (PHP_VERSION_ID >= 70400) {
+    function customErrorHandler($errno, $errstr, $errfile, $errline) {
+        // We know about this deprecation warning exists and it's already been
+        // fixed in the 2.x branch. For BC reasons in the 1.x branch, we'll
+        // ignore this warning to let tests pass.
+        if ($errno === E_DEPRECATED) {
+            if ($errstr === "Function ReflectionType::__toString() is deprecated") {
+                return true;
+            }
+        }
+
+        // Any other error should be left up to PHPUnit to handle
+        return \PHPUnit_Util_ErrorHandler::handleError($errno, $errstr, $errfile, $errline);
+    }
+
+    set_error_handler("customErrorHandler");
+}


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | N/A

### Description

The unit testing CI jobs have been broken for long enough. AppVeyor broke because of a Chocolatey update. PHP 7.4 support has been merged in and fixed.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
