### PR TITLE
Add support for line numbers in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## master
+
+**New**
+
+- A new `highlighter.line_numbers` configuration file option has been added to render line numbers in markup code blocks ([#105](https://github.com/stakx-io/stakx/issues/105), [#112](https://github.com/stakx-io/stakx/pull/112))
+- Added ability to highlight specific lines in markup code blocks ([#105](https://github.com/stakx-io/stakx/issues/105), [#112](https://github.com/stakx-io/stakx/pull/112))
+
 ## 0.2.0 "Guilty Ocelot"
 
 The next major release of stakx is ready and has been battle tested with the [redesign of the BZFlag.org website](https://github.com/BZFlag-Dev/bzflag.org/pull/25).

--- a/composer.lock
+++ b/composer.lock
@@ -917,16 +917,16 @@
         },
         {
             "name": "scrivo/highlight.php",
-            "version": "v9.15.10.0",
+            "version": "v9.17.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scrivo/highlight.php.git",
-                "reference": "9ad3adb4456dc91196327498dbbce6aa1ba1239e"
+                "reference": "5451a9ad6d638559cf2a092880f935c39776134e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scrivo/highlight.php/zipball/9ad3adb4456dc91196327498dbbce6aa1ba1239e",
-                "reference": "9ad3adb4456dc91196327498dbbce6aa1ba1239e",
+                "url": "https://api.github.com/repos/scrivo/highlight.php/zipball/5451a9ad6d638559cf2a092880f935c39776134e",
+                "reference": "5451a9ad6d638559cf2a092880f935c39776134e",
                 "shasum": ""
             },
             "require": {
@@ -936,7 +936,8 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8|^5.7",
-                "symfony/finder": "^2.8"
+                "symfony/finder": "^3.4",
+                "symfony/var-dumper": "^3.4"
             },
             "suggest": {
                 "ext-dom": "Needed to make use of the features in the utilities namespace"
@@ -958,18 +959,18 @@
             "authors": [
                 {
                     "name": "Geert Bergman",
-                    "role": "Project Author",
-                    "homepage": "http://www.scrivo.org/"
+                    "homepage": "http://www.scrivo.org/",
+                    "role": "Project Author"
                 },
                 {
                     "name": "Vladimir Jimenez",
-                    "role": "Contributor",
-                    "homepage": "https://allejo.io"
+                    "homepage": "https://allejo.io",
+                    "role": "Maintainer"
                 },
                 {
                     "name": "Martin Folkers",
-                    "role": "Contributor",
-                    "homepage": "https://twobrain.io"
+                    "homepage": "https://twobrain.io",
+                    "role": "Contributor"
                 }
             ],
             "description": "Server side syntax highlighter that supports 185 languages. It's a PHP port of highlight.js",
@@ -980,7 +981,7 @@
                 "highlight.php",
                 "syntax"
             ],
-            "time": "2019-08-27T04:27:48+00:00"
+            "time": "2019-12-13T21:54:06+00:00"
         },
         {
             "name": "scssphp/scssphp",

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -29,6 +29,7 @@ templates:
   redirect: false
 
 highlighter:
+  line_numbers: true
   languages:
     bzw: _languages/bzw.json
 

--- a/example/_posts/2016-03-02-Github-Flavored-Markdown.md
+++ b/example/_posts/2016-03-02-Github-Flavored-Markdown.md
@@ -33,7 +33,7 @@ echo "Hello World";
 
 ...and here's one in Ruby with some class usage as well.
 
-```ruby
+```ruby{2-4}
 class HelloWorld
    def initialize(name)
       @name = name.capitalize

--- a/src/allejo/stakx/Configuration.php
+++ b/src/allejo/stakx/Configuration.php
@@ -151,6 +151,14 @@ class Configuration
     }
 
     /**
+     * @return bool
+     */
+    public function isHighlighterUsingLineNumbers()
+    {
+        return __::get($this->configuration, 'highlighter.line_numbers', false);
+    }
+
+    /**
      * @return string
      */
     public function getTheme()
@@ -315,6 +323,7 @@ class Configuration
             ],
             'highlighter' => [
                 'enabled' => true,
+                'line_numbers' => false,
                 'languages' => [],
             ],
             'build' => [

--- a/src/allejo/stakx/Markup/RstSyntaxBlock.php
+++ b/src/allejo/stakx/Markup/RstSyntaxBlock.php
@@ -7,6 +7,7 @@
 
 namespace allejo\stakx\Markup;
 
+use allejo\stakx\MarkupEngine\SyntaxHighlighterTrait;
 use Gregwar\RST\Directives\CodeBlock;
 use Gregwar\RST\HTML\Nodes\CodeNode;
 use Gregwar\RST\Parser;
@@ -14,24 +15,22 @@ use Highlight\Highlighter;
 
 class RstSyntaxBlock extends CodeBlock
 {
+    use SyntaxHighlighterTrait;
+
+    public function __construct()
+    {
+        $this->highlighter = new Highlighter();
+    }
+
     public function process(Parser $parser, $node, $variable, $data, array $options)
     {
-        /** @var CodeNode $node */
+        /* @var CodeNode $node */
 
         parent::process($parser, $node, $variable, $data, $options);
 
-        try
-        {
-            $highlighter = new Highlighter();
-            $highlighted = $highlighter->highlight($node->getLanguage(), $node->getValue());
+        $nodeOutput = $this->highlightCode($node->getLanguage(), $node->getValue());
 
-            $nodeOutput = sprintf('<pre><code class="hljs language-%s">%s</code></pre>', $node->getLanguage(), $highlighted->value);
-
-            $node->setRaw(true);
-            $node->setValue($nodeOutput);
-        }
-        catch (\Exception $e)
-        {
-        }
+        $node->setRaw(true);
+        $node->setValue($nodeOutput);
     }
 }

--- a/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
+++ b/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
@@ -15,7 +15,7 @@ use function HighlightUtilities\splitCodeIntoArray;
 
 class MarkdownEngine extends \ParsedownExtra implements MarkupEngineInterface
 {
-    protected $highlighter;
+    use SyntaxHighlighterTrait;
 
     public function __construct()
     {
@@ -67,94 +67,12 @@ class MarkdownEngine extends \ParsedownExtra implements MarkupEngineInterface
         if (isset($block['element']['text']['attributes']) && Service::hasRunTimeFlag(RuntimeStatus::USING_HIGHLIGHTER))
         {
             $cssClass = $block['element']['text']['attributes']['class'];
-            $langDef = $this->parseInfoString($cssClass);
+            $block['markup'] = $this->highlightCode($cssClass, $block['element']['text']['text']);
 
-            try
-            {
-                $highlighted = $this->highlighter->highlight($langDef['language'], $block['element']['text']['text']);
-                $value = $highlighted->value;
-
-                if (Service::hasRunTimeFlag(RuntimeStatus::USING_LINE_NUMBERS) || count($langDef['selectedLines']) > 0)
-                {
-                    $lines = splitCodeIntoArray($value);
-                    $value = '';
-
-                    foreach ($lines as $i => $line)
-                    {
-                        // `$i + 1` since our line numbers are indexed starting at 1
-                        $value .= vsprintf("<div class=\"loc%s\"><span>%s</span></div>\n", [
-                            isset($langDef['selectedLines'][$i + 1]) ? ' highlighted' : '',
-                            $line,
-                        ]);
-                    }
-                }
-
-                $block['markup'] = vsprintf('<pre><code class="hljs language-%s">%s</code></pre>', [
-                    $langDef['language'],
-                    $value,
-                ]);
-
-                // Only return the block if Highlighter knew the language and how to handle it.
-                return $block;
-            }
-            // Exception thrown when language not supported
-            catch (\DomainException $exception)
-            {
-                trigger_error("An unsupported language (${langDef['language']}) was detected in a code block", E_USER_WARNING);
-            }
-            catch (\Exception $e)
-            {
-                trigger_error('An error has occurred in the highlight.php language definition files', E_USER_WARNING);
-            }
+            return $block;
         }
 
         return parent::blockFencedCodeComplete($block);
-    }
-
-    private function parseInfoString($infoString)
-    {
-        $infoString = substr($infoString, 9);
-        $definition = [
-            'language' => $infoString,
-            'selectedLines' => [],
-        ];
-
-        $bracePos = strpos($infoString, '{');
-
-        if ($bracePos === false)
-        {
-            return $definition;
-        }
-
-        $definition['language'] = substr($infoString, 0, $bracePos);
-        $lineDefinition = substr($infoString, $bracePos + 1, -1);
-        $lineNumbers = explode(',', $lineDefinition);
-
-        foreach ($lineNumbers as $lineNumber)
-        {
-            if (strpos($lineNumber, '-') === false)
-            {
-                $definition['selectedLines'][intval($lineNumber)] = true;
-                continue;
-            }
-
-            $extremes = explode('-', $lineNumber);
-
-            if (count($extremes) !== 2)
-            {
-                continue;
-            }
-
-            $start = intval($extremes[0]);
-            $end = intval($extremes[1]);
-
-            for ($i = $start; $i <= $end; $i++)
-            {
-                $definition['selectedLines'][$i] = true;
-            }
-        }
-
-        return $definition;
     }
 
     ///

--- a/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
+++ b/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
@@ -11,7 +11,6 @@ use __;
 use allejo\stakx\RuntimeStatus;
 use allejo\stakx\Service;
 use Highlight\Highlighter;
-use function HighlightUtilities\splitCodeIntoArray;
 
 class MarkdownEngine extends \ParsedownExtra implements MarkupEngineInterface
 {

--- a/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
+++ b/src/allejo/stakx/MarkupEngine/MarkdownEngine.php
@@ -74,7 +74,7 @@ class MarkdownEngine extends \ParsedownExtra implements MarkupEngineInterface
                 $highlighted = $this->highlighter->highlight($langDef['language'], $block['element']['text']['text']);
                 $value = $highlighted->value;
 
-                if (count($langDef['selectedLines']) > 0)
+                if (Service::hasRunTimeFlag(RuntimeStatus::USING_LINE_NUMBERS) || count($langDef['selectedLines']) > 0)
                 {
                     $lines = splitCodeIntoArray($value);
                     $value = '';

--- a/src/allejo/stakx/MarkupEngine/MarkupEngineInterface.php
+++ b/src/allejo/stakx/MarkupEngine/MarkupEngineInterface.php
@@ -31,7 +31,7 @@ interface MarkupEngineInterface
      *
      * @since 0.2.0
      *
-     * @return null|string if null, then no tag or filter will be registered
+     * @return string|null if null, then no tag or filter will be registered
      */
     public function getTemplateTag();
 

--- a/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
+++ b/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright 2018 Vladimir Jimenez
+ * @license   https://github.com/stakx-io/stakx/blob/master/LICENSE.md MIT
+ */
+
 namespace allejo\stakx\MarkupEngine;
 
 use allejo\stakx\RuntimeStatus;
@@ -40,7 +45,6 @@ trait SyntaxHighlighterTrait
                         $line,
                     ]);
                 }
-
             }
 
             return vsprintf('<pre><code class="hljs language-%s">%s</code></pre>', [
@@ -68,7 +72,7 @@ trait SyntaxHighlighterTrait
      */
     private function parseInfoString($infoString)
     {
-        $infoString = substr($infoString, 9);
+        $infoString = str_replace('language-', '', $infoString);
         $definition = [
             'language' => $infoString,
             'selectedLines' => [],
@@ -103,7 +107,7 @@ trait SyntaxHighlighterTrait
             $start = intval($extremes[0]);
             $end = intval($extremes[1]);
 
-            for ($i = $start; $i <= $end; $i++)
+            for ($i = $start; $i <= $end; ++$i)
             {
                 $definition['selectedLines'][$i] = true;
             }

--- a/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
+++ b/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace allejo\stakx\MarkupEngine;
+
+use allejo\stakx\RuntimeStatus;
+use allejo\stakx\Service;
+use Highlight\Highlighter;
+use function HighlightUtilities\splitCodeIntoArray;
+
+trait SyntaxHighlighterTrait
+{
+    /** @var Highlighter */
+    protected $highlighter;
+
+    /**
+     * @param string $infoString
+     * @param string $rawCode
+     *
+     * @return string
+     */
+    protected function highlightCode($infoString, $rawCode)
+    {
+        $langDef = $this->parseInfoString($infoString);
+
+        try
+        {
+            $highlighted = $this->highlighter->highlight($langDef['language'], $rawCode);
+            $value = $highlighted->value;
+
+            if (Service::hasRunTimeFlag(RuntimeStatus::USING_LINE_NUMBERS) || count($langDef['selectedLines']) > 0)
+            {
+                $lines = splitCodeIntoArray($value);
+                $value = '';
+
+                foreach ($lines as $i => $line)
+                {
+                    // `$i + 1` since our line numbers are indexed starting at 1
+                    $value .= vsprintf("<div class=\"loc%s\"><span>%s</span></div>\n", [
+                        isset($langDef['selectedLines'][$i + 1]) ? ' highlighted' : '',
+                        $line,
+                    ]);
+                }
+
+            }
+
+            return vsprintf('<pre><code class="hljs language-%s">%s</code></pre>', [
+                $langDef['language'],
+                $value,
+            ]);
+        }
+        // Exception thrown when language not supported
+        catch (\DomainException $exception)
+        {
+            trigger_error("An unsupported language (${langDef['language']}) was detected in a code block", E_USER_WARNING);
+        }
+        catch (\Exception $e)
+        {
+            trigger_error('An error has occurred in the highlight.php language definition files', E_USER_WARNING);
+        }
+
+        return $rawCode;
+    }
+
+    /**
+     * @param string $infoString
+     *
+     * @return array
+     */
+    private function parseInfoString($infoString)
+    {
+        $infoString = substr($infoString, 9);
+        $definition = [
+            'language' => $infoString,
+            'selectedLines' => [],
+        ];
+
+        $bracePos = strpos($infoString, '{');
+
+        if ($bracePos === false)
+        {
+            return $definition;
+        }
+
+        $definition['language'] = substr($infoString, 0, $bracePos);
+        $lineDefinition = substr($infoString, $bracePos + 1, -1);
+        $lineNumbers = explode(',', $lineDefinition);
+
+        foreach ($lineNumbers as $lineNumber)
+        {
+            if (strpos($lineNumber, '-') === false)
+            {
+                $definition['selectedLines'][intval($lineNumber)] = true;
+                continue;
+            }
+
+            $extremes = explode('-', $lineNumber);
+
+            if (count($extremes) !== 2)
+            {
+                continue;
+            }
+
+            $start = intval($extremes[0]);
+            $end = intval($extremes[1]);
+
+            for ($i = $start; $i <= $end; $i++)
+            {
+                $definition['selectedLines'][$i] = true;
+            }
+        }
+
+        return $definition;
+    }
+}

--- a/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
+++ b/src/allejo/stakx/MarkupEngine/SyntaxHighlighterTrait.php
@@ -12,12 +12,17 @@ use allejo\stakx\Service;
 use Highlight\Highlighter;
 use function HighlightUtilities\splitCodeIntoArray;
 
+/**
+ * @since 0.2.1
+ */
 trait SyntaxHighlighterTrait
 {
     /** @var Highlighter */
     protected $highlighter;
 
     /**
+     * @since 0.2.1
+     *
      * @param string $infoString
      * @param string $rawCode
      *
@@ -66,6 +71,8 @@ trait SyntaxHighlighterTrait
     }
 
     /**
+     * @since 0.2.1
+     *
      * @param string $infoString
      *
      * @return array

--- a/src/allejo/stakx/RuntimeStatus.php
+++ b/src/allejo/stakx/RuntimeStatus.php
@@ -20,4 +20,5 @@ abstract class RuntimeStatus
     const USING_CACHE = 16;
     const USING_DRAFTS = 32;
     const USING_HIGHLIGHTER = 64;
+    const USING_LINE_NUMBERS = 256;
 }

--- a/src/allejo/stakx/Website.php
+++ b/src/allejo/stakx/Website.php
@@ -164,6 +164,10 @@ class Website
 
         Service::setRuntimeFlag(RuntimeStatus::USING_HIGHLIGHTER);
 
+        if ($this->getConfiguration()->isHighlighterUsingLineNumbers()) {
+            Service::setRuntimeFlag(RuntimeStatus::USING_LINE_NUMBERS);
+        }
+
         foreach ($this->getConfiguration()->getHighlighterCustomLanguages() as $lang => $path)
         {
             $fullPath = fs::absolutePath($path);

--- a/tests/allejo/stakx/Test/MarkupEngine/MarkdownEngineTest.php
+++ b/tests/allejo/stakx/Test/MarkupEngine/MarkdownEngineTest.php
@@ -33,7 +33,7 @@ class MarkdownEngineTest extends PHPUnit_Stakx_TestCase
 
     public function testCodeBlockWithLanguage()
     {
-        $codeBlock = <<<CODE
+        $codeBlock = <<<'CODE'
 ```php
 <?php
 
@@ -43,6 +43,99 @@ CODE;
         $compiled = $this->mdEngine->parse($codeBlock);
 
         $this->assertContains('<code class="hljs language-php">', $compiled);
+    }
+
+    public function testCodeBlockWithLanguageSingleLineNumber()
+    {
+        $codeBlock = <<<'CODE'
+```php{3}
+<?php
+
+echo "hello world";
+```
+CODE;
+        $compiled = $this->mdEngine->parse($codeBlock);
+        $chunks = explode("\n", $compiled);
+
+        $this->assertContains('<code class="hljs language-php">', $chunks[0]);
+        $this->assertNotContains('<div class="loc highlighted">', $chunks[1]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[2]);
+    }
+
+    public function testCodeBlockWithLanguageSingleLineRange()
+    {
+        $codeBlock = <<<'CODE'
+```php{6-8}
+<?php
+
+/**
+ * Hello World
+ *
+ * @api
+ * @since 1.0.0
+ * @param string $str Some string parameter
+ */
+```
+CODE;
+        $compiled = $this->mdEngine->parse($codeBlock);
+        $chunks = explode("\n", $compiled);
+
+        $this->assertContains('<code class="hljs language-php">', $chunks[0]);
+        $this->assertNotContains('<div class="loc highlighted">', $chunks[4]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[5]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[6]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[7]);
+    }
+
+    public function testCodeBlockWithLanguageTwoSingleNumbers()
+    {
+        $codeBlock = <<<'CODE'
+```php{4,7}
+<?php
+
+/**
+ * Hello World
+ *
+ * @api
+ * @since 1.0.0
+ * @param string $str Some string parameter
+ */
+```
+CODE;
+        $compiled = $this->mdEngine->parse($codeBlock);
+        $chunks = explode("\n", $compiled);
+
+        $this->assertContains('<code class="hljs language-php">', $chunks[0]);
+        $this->assertNotContains('<div class="loc highlighted">', $chunks[0]);
+        $this->assertNotContains('<div class="loc highlighted">', $chunks[2]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[3]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[6]);
+    }
+
+    public function testCodeBlockWithLanguageSingleNumberAndRange()
+    {
+        $codeBlock = <<<'CODE'
+```php{6-8,1}
+<?php
+
+/**
+ * Hello World
+ *
+ * @api
+ * @since 1.0.0
+ * @param string $str Some string parameter
+ */
+```
+CODE;
+        $compiled = $this->mdEngine->parse($codeBlock);
+        $chunks = explode("\n", $compiled);
+
+        $this->assertContains('<code class="hljs language-php">', $chunks[0]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[0]);
+        $this->assertNotContains('<div class="loc highlighted">', $chunks[2]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[5]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[6]);
+        $this->assertContains('<div class="loc highlighted">', $chunks[7]);
     }
 
     public function testCodeBlockWithNoLanguage()


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | Closes #105

### Description

<!--
  - Describe what bug or issue your pull request is fixing.
  - Describe what new features your pull request are introducing.
-->

Adds the ability to start highlighting specific lines in code blocks. Here's the implemented syntax.

- `lang` - Don't highlight any lines
- `lang{4}` - Highlight just line 4
- `lang{4-6}` - Highlight the range of lines from 4 to 6 (inclusive)
- `lang{1,5}` - Highlight just lines 1 and 5 on their own
- `lang{1-3,5}` - Highlight 1 through 3 and then 5 on its own
- `lang{5,7,2-3}` - The order of lines don't matter
  -  However, specifying `3-2` will not work.

This also adds the new `highlighter.line_numbers` configuration file option that will allow users to opt-in to displaying line numbers for all code blocks.

This feature has been added to both the Markdown and RST engines.

### Check List

- [x] Added appropriate PhpDoc for modifications
- [x] Added unit test to ensure fix works as intended
