### PR TITLE
Add `redirects` variable that contains of map of from/to URLs

### DIFF
--- a/example/_pages/redirects.twig
+++ b/example/_pages/redirects.twig
@@ -1,0 +1,10 @@
+---
+permalink: /_redirects
+---
+
+# Netlify style redirects
+#   https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
+
+{% for from, to in redirects  %}
+{{ from }}    {{ to }}
+{% endfor %}

--- a/src/allejo/stakx/Compiler.php
+++ b/src/allejo/stakx/Compiler.php
@@ -79,6 +79,7 @@ class Compiler
         DataManager $dataManager,
         MenuManager $menuManager,
         PageManager $pageManager,
+        RedirectMapper $redirectMapper,
         EventDispatcherInterface $eventDispatcher,
         LoggerInterface $logger
     ) {
@@ -99,6 +100,7 @@ class Compiler
         $this->templateBridge->setGlobalVariable('menu', $menuManager->getSiteMenu());
         $this->templateBridge->setGlobalVariable('pages', $pageManager->getJailedStaticPageViews());
         $this->templateBridge->setGlobalVariable('repeaters', $pageManager->getJailedRepeaterPageViews());
+        $this->templateBridge->setGlobalVariable('redirects', $redirectMapper->getRedirects());
     }
 
     /**

--- a/src/allejo/stakx/Compiler.php
+++ b/src/allejo/stakx/Compiler.php
@@ -21,6 +21,7 @@ use allejo\stakx\Event\CompilerPreRenderDynamicPageView;
 use allejo\stakx\Event\CompilerPreRenderRepeaterPageView;
 use allejo\stakx\Event\CompilerPreRenderStaticPageView;
 use allejo\stakx\Event\CompilerTemplateCreation;
+use allejo\stakx\Event\RedirectPreOutput;
 use allejo\stakx\Exception\FileAwareException;
 use allejo\stakx\Filesystem\WritableFolder;
 use allejo\stakx\FrontMatter\ExpandedValue;
@@ -374,6 +375,14 @@ class Compiler
                 'site' => $this->configuration->getConfiguration(),
             ]);
 
+            $redirectEvent = new RedirectPreOutput(
+                $redirect,
+                $pageView->getPermalink(),
+                $pageView,
+                $redirectPageView
+            );
+            $this->eventDispatcher->dispatch(RedirectPreOutput::NAME, $redirectEvent);
+
             $this->compileStaticPageView($redirectPageView);
         }
     }
@@ -406,6 +415,14 @@ class Compiler
                 $redirectPageView->evaluateFrontMatter([], [
                     'site' => $this->configuration->getConfiguration(),
                 ]);
+
+                $redirectEvent = new RedirectPreOutput(
+                    $redirect->getEvaluated(),
+                    $permalinks[$index]->getEvaluated(),
+                    $pageView,
+                    $redirectPageView
+                );
+                $this->eventDispatcher->dispatch(RedirectPreOutput::NAME, $redirectEvent);
 
                 $this->compilePageView($redirectPageView);
             }

--- a/src/allejo/stakx/Event/RedirectPreOutput.php
+++ b/src/allejo/stakx/Event/RedirectPreOutput.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace allejo\stakx\Event;
+
+use allejo\stakx\Document\BasePageView;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * This event is fired before a redirect is created. This event provides read-only access to the parent PageView and
+ * write access to the PageView generated to write a flat redirect file.
+ *
+ * @since 0.2.1
+ */
+class RedirectPreOutput extends Event
+{
+    const NAME = 'redirect.preoutput';
+
+    /** @var string */
+    private $fromUrl;
+
+    /** @var string */
+    private $toUrl;
+
+    /** @var BasePageView */
+    private $parentPageView;
+
+    /** @var BasePageView */
+    private $redirectPageView;
+
+    /**
+     * @param string       $from
+     * @param string       $to
+     * @param BasePageView $pageView
+     * @param BasePageView $redirectPageView
+     */
+    public function __construct($from, $to, $pageView, $redirectPageView)
+    {
+        $this->fromUrl = $from;
+        $this->toUrl = $to;
+        $this->parentPageView = $pageView;
+        $this->redirectPageView = $redirectPageView;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFromUrl()
+    {
+        return $this->fromUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToUrl()
+    {
+        return $this->toUrl;
+    }
+
+    /**
+     * Read-only access to the PageView who this redirect belongs to.
+     *
+     * @return BasePageView
+     */
+    public function getParentPageView()
+    {
+        return clone $this->parentPageView;
+    }
+
+    /**
+     * The PageView that was generated to create this redirect as a flat file.
+     *
+     * @return BasePageView
+     */
+    public function getRedirectPageView()
+    {
+        return $this->redirectPageView;
+    }
+}

--- a/src/allejo/stakx/EventSubscriber/RedirectSubscriber.php
+++ b/src/allejo/stakx/EventSubscriber/RedirectSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace allejo\stakx\EventSubscriber;
+
+use allejo\stakx\Document\DynamicPageView;
+use allejo\stakx\Document\RepeaterPageView;
+use allejo\stakx\Document\StaticPageView;
+use allejo\stakx\Event\PageViewAdded;
+use allejo\stakx\RedirectMapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class RedirectSubscriber implements EventSubscriberInterface
+{
+    /** @var RedirectMapper */
+    private $redirectMapper;
+
+    public function __construct(RedirectMapper $redirectMapper)
+    {
+        $this->redirectMapper = $redirectMapper;
+    }
+
+    public function registerRedirect(PageViewAdded $event)
+    {
+        $pageView = $event->getPageView();
+
+        if ($pageView instanceof StaticPageView || $pageView instanceof DynamicPageView)
+        {
+            $redirects = $pageView->getRedirects();
+
+            foreach ($redirects as $redirect)
+            {
+                $this->redirectMapper->registerRedirect($redirect, $pageView->getPermalink());
+            }
+        }
+        elseif ($pageView instanceof RepeaterPageView)
+        {
+            $permalinks = $pageView->getRepeaterPermalinks();
+
+            foreach ($pageView->getRepeaterRedirects() as $repeaterRedirect)
+            {
+                foreach ($repeaterRedirect as $index => $redirect)
+                {
+                    $this->redirectMapper->registerRedirect(
+                        $redirect->getEvaluated(),
+                        $permalinks[$index]->getEvaluated()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            PageViewAdded::NAME => 'registerRedirect',
+        ];
+    }
+}

--- a/src/allejo/stakx/RedirectMapper.php
+++ b/src/allejo/stakx/RedirectMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace allejo\stakx;
+
+class RedirectMapper
+{
+    /** @var array<string, string> */
+    private $urlMap;
+
+    public function __construct()
+    {
+        $this->urlMap = [];
+    }
+
+    public function registerRedirect($from, $to)
+    {
+        $this->urlMap[$from] = $to;
+    }
+
+    public function getRedirects()
+    {
+        return $this->urlMap;
+    }
+}

--- a/tests/allejo/stakx/Test/CompilerTest.php
+++ b/tests/allejo/stakx/Test/CompilerTest.php
@@ -292,6 +292,7 @@ class CompilerTest extends PHPUnit_Stakx_TestCase
             $this->getMockDataManager(),
             $this->getMockMenuManager(),
             $pageManager,
+            $this->getMockRedirectMapper(),
             $this->getMockEventDistpatcher(),
             $this->getMockLogger()
         );

--- a/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
+++ b/tests/allejo/stakx/Test/PHPUnit_Stakx_TestCase.php
@@ -23,6 +23,7 @@ use allejo\stakx\MarkupEngine\MarkdownEngine;
 use allejo\stakx\MarkupEngine\MarkupEngineManager;
 use allejo\stakx\MarkupEngine\PlainTextEngine;
 use allejo\stakx\MarkupEngine\RstEngine;
+use allejo\stakx\RedirectMapper;
 use allejo\stakx\RuntimeStatus;
 use allejo\stakx\Service;
 use allejo\stakx\Templating\Twig\TwigExtension;
@@ -371,6 +372,20 @@ abstract class PHPUnit_Stakx_TestCase extends \PHPUnit_Framework_TestCase
         ]);
 
         return $markupEngine;
+    }
+
+    /**
+     * @return RedirectMapper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockRedirectMapper()
+    {
+        $stub = $this->getMockBuilder(RedirectMapper::class)
+            ->getMock()
+        ;
+
+        $stub->method('getRedirects')->willReturn([]);
+
+        return $stub;
     }
 
     /**


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed issues  | Closes #97

### Description

- Introduce a new `RedirectPreOutput` event (that's currently unused by stakx core but it may prove useful in the future
- Add a new global `redirects` variable to our template engine that is an associative array where the key is the "from" URL and the value is the "to" URL

This change introduces a new reserved variable name, `redirects`.

### Check List

- [x] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
