### PR TITLE
Serve Linked Assets at the right time in serve

### DIFF
--- a/src/allejo/stakx/Console/Command/BuildCommand.php
+++ b/src/allejo/stakx/Console/Command/BuildCommand.php
@@ -59,6 +59,7 @@ class BuildCommand extends ContainerAwareCommand
         {
             $this->configureConfigurationFile($input);
 
+            /** @var Website $website */
             $website = $this->getContainer()->get(Website::class);
             $website->build();
 

--- a/src/allejo/stakx/Server/WebServer.php
+++ b/src/allejo/stakx/Server/WebServer.php
@@ -75,6 +75,12 @@ class WebServer
             $context = new RequestContext($urlPath);
             $matcher = new UrlMatcher($routes, $context);
 
+            // If we have a Linked Asset, let's serve it
+            if (($file = $assetManager->getExplicitAsset(self::normalizePath($urlPath))) !== null)
+            {
+                return self::makeResponse($file);
+            }
+
             try
             {
                 $parameters = $matcher->match($urlPath);
@@ -88,12 +94,6 @@ class WebServer
             }
             catch (ResourceNotFoundException $e)
             {
-                // If we have a "manual" asset, let's serve from it
-                if (($file = $assetManager->getExplicitAsset(self::normalizePath($urlPath))) !== null)
-                {
-                    return self::makeResponse($file);
-                }
-
                 // Our AssetManager only populates its registry of assets when files are copied at build time. Because
                 // the web server doesn't perform the full site compilation, our manager is not populated. For this
                 // reason, we manually look through the filesystem and load from there.


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | fixes #129 

### Description

<!--
  - Describe what bug or issue your pull request is fixing.
  - Describe what new features your pull request are introducing.
-->

Linked assets end up with a route that matches their parent collection item and therefore, the web server attempts to treat them as a dynamic pageview since that's where the collection item belongs.

For example, `documentation/server-administration/player-slots.jpg` will match the `documentation/server-administration/{docpath}` route from the dynamic pageview.

This PR changes the logic so that linked assets are handled first before the dynamic pageview controller has time to kick in.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [ ] Added unit test to ensure fix works as intended
