### PR TITLE
Add the ability to automatically set rel and target on external links

### DIFF
--- a/src/allejo/stakx/Configuration.php
+++ b/src/allejo/stakx/Configuration.php
@@ -217,6 +217,30 @@ class Configuration
         return __::get($this->configuration, 'templates.redirect');
     }
 
+    /**
+     * @return array
+     */
+    public function getInternalHosts()
+    {
+        return __::get($this->configuration, 'links.internalhosts', []);
+    }
+
+    /**
+     * @return false|string
+     */
+    public function getExternalLinkRel()
+    {
+        return __::get($this->configuration, 'links.externalrel', false);
+    }
+
+    /**
+     * @return false|string
+     */
+    public function getExternalLinkTarget()
+    {
+        return __::get($this->configuration, 'links.externaltarget', false);
+    }
+
     ///
     // Parsing
     ///

--- a/src/allejo/stakx/Templating/Twig/Extension/AFunction.php
+++ b/src/allejo/stakx/Templating/Twig/Extension/AFunction.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright 2023 Vladimir Jimenez
+ * @license   https://github.com/stakx-io/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Templating\Twig\Extension;
+
+use __;
+use Twig\TwigFunction;
+use Twig_Environment;
+
+class AFunction extends AbstractTwigExtension implements TwigFunctionInterface
+{
+    public function __invoke(Twig_Environment $env, $href, $text, $attributes = [])
+    {
+        $format = '<a href="%s"%s>%s</a>';
+
+        $config = $env->getGlobals()['site'];
+        $internalHosts = __::get($config, 'links.internalhosts', []);
+        $externalRel = __::get($config, 'links.externalrel', false);
+        $externalTarget = __::get($config, 'links.externaltarget', false);
+
+        if ($externalRel || $externalTarget)
+        {
+            // Parse out the host from the URL, if any
+            $host = parse_url($href, PHP_URL_HOST);
+
+            // If a host was found, and it is not on the list of internal hosts, add the attributes
+            if ($host !== NULL && !in_array($host, $internalHosts))
+            {
+                if ($externalRel && !isset($attributes['rel']))
+                {
+                    $attributes['rel'] = $externalRel;
+                }
+
+                if ($externalTarget && !isset($attributes['target']))
+                {
+                    $attributes['target'] = $externalTarget;
+                }
+            }
+        }
+
+        $attrStr = '';
+        if (sizeof($attributes) > 0)
+        {
+            $attrStr = ' ' . implode(' ', array_filter(array_map(
+                function ($k, $v)
+                {
+                    if (strlen($v) === 0)
+                    {
+                        return '';
+                    }
+
+                    return $k .= '="' . htmlspecialchars($v) . '"';
+                },
+                array_keys($attributes),
+                $attributes
+            )));
+        }
+
+        return sprintf($format, $href, $attrStr, $text);
+    }
+
+    public static function get()
+    {
+        return new TwigFunction('a', new self(), [
+            'needs_environment' => true,
+        ]);
+    }
+}

--- a/tests/allejo/stakx/Test/Templating/Twig/Extension/AFunctionTest.php
+++ b/tests/allejo/stakx/Test/Templating/Twig/Extension/AFunctionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright 2023 Vladimir Jimenez
+ * @license   https://github.com/stakx-io/stakx/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\stakx\Test\Templating\Twig\Extension;
+
+use allejo\stakx\MarkupEngine\MarkupEngineManager;
+use allejo\stakx\Templating\Twig\Extension\AFunction;
+use allejo\stakx\Templating\Twig\TwigExtension;
+use allejo\stakx\Test\PHPUnit_Stakx_TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class AFunctionTest extends PHPUnit_Stakx_TestCase
+{
+    /** @var \Twig_Environment */
+    private $twig_env;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        /** @var MockObject|MarkupEngineManager $markupEngine */
+        $markupEngine = $this->getMock(MarkupEngineManager::class);
+
+        $extension = new TwigExtension($markupEngine);
+        $extension->addFilters([new AFunction()]);
+
+        $loader = new \Twig_Loader_Filesystem();
+        $this->twig_env = new \Twig_Environment($loader);
+        $this->twig_env->addExtension($extension);
+    }
+
+    public static function dataProvider()
+    {
+
+        return [
+            [
+                '<a href="/">home</a>', '/', 'home', [], []
+            ],
+            [
+                '<a href="/" class="link dark">classy home</a>', '/', 'classy home', ['class' => 'link dark'], []
+            ],
+            [
+                '<a href="https://example.com">external</a>', 'https://example.com', 'external', [], []
+            ],
+            [
+                '<a href="https://example.com" rel="nofollow" target="_blank">external with config</a>', 'https://example.com', 'external with config', [], [
+                    'externalrel' => 'nofollow',
+                    'externaltarget' => '_blank'
+                ]
+            ],
+            [
+                '<a href="https://example.com" target="_blank">external with config and override</a>', 'https://example.com', 'external with config and override', ['rel' => ''], [
+                    'externalrel' => 'nofollow',
+                    'externaltarget' => '_blank'
+                ]
+            ],
+            [
+                '<a href="https://internalhost.example.com">internal</a>', 'https://internalhost.example.com', 'internal', [], [
+                    'internalhosts' => ['internalhost.example.com'],
+                    'externalrel' => 'nofollow',
+                    'externaltarget' => '_blank'
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $expected
+     * @param $href
+     * @param $text
+     * @param $attributes
+     * @param $linksConfig
+     */
+    public function testAFunction($expected, $href, $text, $attributes, $linksConfig)
+    {
+        $this->twig_env->addGlobal('site', [
+            'links' => $linksConfig,
+        ]);
+
+        $filter = new AFunction();
+        $html = $filter($this->twig_env, $href, $text, $attributes);
+
+        $this->assertEquals($expected, $html);
+    }
+}


### PR DESCRIPTION
### Summary

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | 

### Description

* Added three configuration values under the 'links' section:
  - internalhosts: array of hostnames to ignore when deciding to add rel or target
  - externalrel: value of the rel attribute that should be added to external links
  - externaltarget: value of the target attribute that should be added to external links
* For Markdown, inline links are processed based on the configuration values
* For Twig, an 'a' function was added that takes href, text, and an array of attribute values and returns an HTML fragment with the 'a' tag. The configuration values are used to determine if rel or target should be added to external links. Additionally, it is possible to override the configuration by passing rel or target as an attribute, and passing an empty string for either will prevent the attribute from being added at all.

### Check List

- [ ] Added appropriate PhpDoc for modifications
- [X] Added unit test to ensure fix works as intended
